### PR TITLE
Improve IAnalogSensorToIWear error handlings

### DIFF
--- a/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp
+++ b/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp
@@ -148,9 +148,7 @@ public:
 
     bool getForceTorque6D(Vector3& force3D, Vector3& torque3D) const override
     {
-        if (!handler.readData()) {
-            return false;
-        }
+        bool dataOk = handler.readData();
 
         // Dirty workaround to set the status from a const method
         auto nonConstThis = const_cast<ForceTorque6DSensor*>(this);
@@ -158,7 +156,7 @@ public:
 
         // TODO: The positions of force and torques are hardcoded. Forces should be the first
         //       triplet of elements of the read vector and torques the second one.
-        bool ok = handler.getData(force3D, offset) && handler.getData(torque3D, offset + 3);
+        bool ok = dataOk && handler.getData(force3D, offset) && handler.getData(torque3D, offset + 3);
         if (groundReactionFT) {
             force3D[0] = -1 * force3D[0];
             force3D[1] = -1 * force3D[1];
@@ -185,15 +183,13 @@ public:
 
     bool getForce3D(Vector3& force3D) const override
     {
-        if (!handler.readData()) {
-            return false;
-        }
+        bool dataOk = handler.readData();
 
         // Dirty workaround to set the status from a const method
         auto nonConstThis = const_cast<Force3DSensor*>(this);
         nonConstThis->setStatus(handler.getStatus());
 
-        return handler.getData(force3D, offset);
+        return dataOk && handler.getData(force3D, offset);
     }
 };
 
@@ -210,15 +206,13 @@ public:
 
     bool getTorque3D(Vector3& torque3D) const override
     {
-        if (!handler.readData()) {
-            return false;
-        }
+        bool dataOk = handler.readData();
 
         // Dirty workaround to set the status from a const method
         auto nonConstThis = const_cast<Torque3DSensor*>(this);
         nonConstThis->setStatus(handler.getStatus());
 
-        return handler.getData(torque3D, offset);
+        return dataOk && handler.getData(torque3D, offset);
     }
 };
 
@@ -235,15 +229,13 @@ public:
 
     bool getTemperature(double& temperature) const override
     {
-        if (!handler.readData()) {
-            return false;
-        }
+        bool dataOk = handler.readData();
 
         // Dirty workaround to set the status from a const method
         auto nonConstThis = const_cast<TemperatureSensor*>(this);
         nonConstThis->setStatus(handler.getStatus());
 
-        return handler.getData(temperature, offset);
+        return dataOk && handler.getData(temperature, offset);
     }
 };
 
@@ -260,15 +252,13 @@ public:
 
     bool getPressure(std::vector<double>& pressure) const override
     {
-        if (!handler.readData()) {
-            return false;
-        }
+        bool dataOk = handler.readData();
 
         // Dirty workaround to set the status from a const method
         auto nonConstThis = const_cast<SkinSensor*>(this);
         nonConstThis->setStatus(handler.getStatus());
 
-        return handler.getData(pressure, offset);
+        return dataOk && handler.getData(pressure, offset);
     }
 };
 


### PR DESCRIPTION
Following https://github.com/robotology/wearables/issues/43, with this PR I want to improve the handling of error status in `IAnalogSensorToIWear`.

**IAnalog sensor status**
To sum-up, an [`IAnalogSensor`](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/include/yarp/dev/IAnalogSensor.h) has multiple channels, and each channel has a state that can be accessed through [`getState(idx)`](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/include/yarp/dev/IAnalogSensor.h#L57) (possible states: `OK`, `ERROR`, `OVERFLOW`, `TIMEOUT`). Plus, the [`read()`](https://github.com/robotology/yarp/blob/master/src/libYARP_dev/include/yarp/dev/IAnalogSensor.h#L50) method also return a value of the status of the `IAnalogSensor` which depends on how it is implemented at the device level but in general it is cumulative of the status of all the channels (see for example the [`ftShoeDriver`](https://github.com/robotology/forcetorque-yarp-devices/blob/master/ftShoe/ftshoeDriver.cpp#L251) which return a combined status of two sensor devices).

**IAnalog to wearable status**
Unfortunately, for a given general `IAnalogSensor` we can not be sure about the relationship between what is returned by `read()` and the actual status of the channels.  At the moment in the `IAnalogSensorToWearable`, we uses both the values:
- in [`readData()`](https://github.com/robotology/wearables/blob/master/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp#L34) it only checks if the `read()` method return `OK`, and in that case we assume we are able to read the data from the `IAnalogSensor` interface.
- in [`getStatus()`](https://github.com/robotology/wearables/blob/master/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp#L50) then it parses all the channels checking the state (`getState()`) and set the `wearables::SensorStatus` according to a hierarchy as follow: `ERROR` > `OVF` > `TIMEOUT` > `OK` (which means that if a channel has a status with higher importance, that status will be set as the status of for the wearable sensor).

Assuming that the `IAnalogSensor` device is implemented properly, this implementation seems to work fine (with implmented properly I mean that if `read()` doesn't return `OK`, then there will be at least one channel with status different from `OK` and vice versa).

**what is missing/can be improved**
- [x] the status of the `wearable` sensor is never set differently from `OK` since the [`setStatus()`](https://github.com/robotology/wearables/blob/master/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp#L194) is reached only if the [`read()`](https://github.com/robotology/wearables/blob/master/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp#L41) method returns `OK` (which means that most likely also [`getStatus()`](https://github.com/robotology/wearables/blob/master/devices/IAnalogSensorToIWear/src/IAnalogSensorToIWear.cpp#L50) will return `OK`).
