### PR TITLE
restore CI branch deps

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -27,8 +27,7 @@ cmake --build . --config $TRAVIS_BUILD_TYPE --target install
 
 # Install icub-main
 cd $HOME/git
-git clone --depth 1 -b devel https://github.com/robotology/icub-main.git
-# git clone --depth 1 -b $DEPS_BRANCH https://github.com/robotology/icub-main.git
+git clone --depth 1 -b $DEPS_BRANCH https://github.com/robotology/icub-main.git
 cd icub-main
 mkdir build && cd build
 cmake .. \

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,6 @@ stage_osx:
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DEPS_INSTALL_PREFIX/lib
     - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$DEPS_INSTALL_PREFIX
     - export CMAKE_BUILD_OPTIONS=""
-    # Temporary use devel branches for dependencies waiting the post Yarp3 alignment
-    - export DEPS_BRANCH="devel"
     # Setup ccache
     - brew install ccache
     - export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Given that the compatibility with YARP `master` branch was fixed (https://github.com/robotology/wearables/issues/46) I am restoring the standard CI branch dependencies. I am also removing the dependency on icub `devel` since probably the reason for that dependency is now solved.