### PR TITLE
Add documentation on how to run werable devices

### DIFF
--- a/doc/How-to-run-FTshoes.md
+++ b/doc/How-to-run-FTshoes.md
@@ -1,0 +1,27 @@
+# How to run FTShoes as Wearable Device
+
+This page describes how to run the [FTShoes](https://github.com/robotology/forcetorque-yarp-devices/tree/master/ftShoe) as a wearable device source. Further information on how to install and use the shoes can be found at https://github.com/robotology/forcetorque-yarp-devices/tree/master/ftShoe.
+
+The configuration file to run the FTShoes as wearable device is [`FTShoesWearableDevice.xml`](https://github.com/robotology/wearables/blob/master/app/xml/FTShoesWearableDevice.xml), and it can be launched with:
+```
+yarprobotinterface --config FTShoesWearableDevice.xml
+```
+The two shoes can also be launched separately using [`FTShoeLeftWearableDevice.xml`](https://github.com/robotology/wearables/blob/master/app/xml/FTShoeLeftWearableDevice.xml) and [`FTShoeRightWearableDevice.xml`](https://github.com/robotology/wearables/blob/master/app/xml/FTShoeRightWearableDevice.xml).
+
+**Before running**
+Before running the device make sure that:
+- [`yarpserver`](https://www.yarp.it/yarpserver.html) is running
+- The shoes are connected and recognized by the laptop
+- The can address of the FT sensors in the shoes is the same of the configuration file (e.g. `ftShoe_Left_Front` -> `<param name="canAddress"> 0x01 </param>`)
+- There is not another device running that is using the port names. In case multiple pairs of shoes have to run simultaneously, it is necessary to differentiate the name of the ports like in [`FTShoesWearableDevice_2.xml`](https://github.com/robotology/wearables/blob/master/app/xml/FTShoesWearableDevice_2.xml).
+
+
+**Calibration**
+The FT data streamed by the shoes may be characterized by an offset. The procedure for removing the offset is described at https://github.com/robotology/forcetorque-yarp-devices/tree/master/ftShoe#how-to-use-the-ftshoes.
+
+**Data**
+If the device is running correctly, the stream of wearable data can be read with:
+```
+yarp read ... /FTShoeLeft/WearableData/data:o
+yarp read ... /FTShoeRight/WearableData/data:o
+```

--- a/doc/How-to-run-XsensSuit.md
+++ b/doc/How-to-run-XsensSuit.md
@@ -1,0 +1,48 @@
+# How to run Xsens suit as Wearable Device
+
+This page describes how to run the [Xsens suit](https://www.xsens.com/motion-capture) as a wearable device source. Further information on how to install can be found at https://github.com/robotology/human-dynamics-estimation/wiki/Set-up-Machine-for-running-HDE#xsens-only-for-windows, while for more information on the Xsens suit device tutorials are available at https://tutorial.xsens.com/.
+
+The configuration file to run the XsensSuit as wearable device is [`XsensSuitWearableDevice.xml`](https://github.com/robotology/wearables/blob/master/app/xml/XsensSuitWearableDevice.xml), and it can be launched with:
+```
+yarprobotinterface --config XsensSuitWearableDevice.xml
+```
+Once the device is started
+
+**Before running**
+Before running the device make sure that:
+- [`yarpserver`](https://www.yarp.it/yarpserver.html) is running
+- The router/receiver of the suit is connected to the laptop, the suit is powered on, and the pendrive with the licence is instered on the laptop.
+- There is not another device running that is using the port names. In case multiple suits have to run simultaneously, it is necessary to differentiate the name of the ports.
+- In the [configuration file](https://github.com/robotology/wearables/blob/master/app/xml/XsensSuitWearableDevice.xml), the following parameters are set propery:
+  - `xsens-rundeps-dir`: Folder where XsensMVN runtime dependencies are stored.
+  - `default-calibration-type`: Calibration type to be used (available values: `NposeWalk`, `TposeWalk`, `Npose`, `Tpose`).
+  - `minimum-calibration-quality-required`: Minimum calibration quality to be considered good enought to be applied and allow the acquisition to start (available values: `Poor`, `Acceptable`, `Good`).
+  - `body-dimensions`: Subject=specific body dimensions.
+- The subject is wearing the suit correctly 
+
+**Calibration**
+In order to acquire data from the Xsens suit it is required to perform a calibration procedure, the type of procedure is set trought the configuration file (`default-calibration-type`).
+The calibration is started sending the following command:
+```
+yarp rpc /XsensSuit/Control/rpc:i
+calibrate
+```
+The device will give as output the indication for performing the calibration, and the final quality of the calibration.
+
+In case the calibration does not meet the minimum quality requirement, new calibration can be performed with the same command. In case a new calibration is required after the acquisition is started, it is necessary to stop the acquisition befor performing a new calibration:
+```
+yarp rpc /XsensSuit/Control/rpc:i
+stopAcquisition
+calibrate
+```
+
+**Data**
+Once the calibration procedure is completed with the required minimum quality level, the data acquisition is started sending the following command:
+```
+yarp rpc /XsensSuit/Control/rpc:i
+startAcquisition
+```
+If the device is running correctly, the stream of wearable data can be read with:
+```
+/XsensSuit/WearableData/data:o
+```

--- a/doc/How-to-run-XsensSuit.md
+++ b/doc/How-to-run-XsensSuit.md
@@ -6,7 +6,7 @@ The configuration file to run the XsensSuit as wearable device is [`XsensSuitWea
 ```
 yarprobotinterface --config XsensSuitWearableDevice.xml
 ```
-Once the device is started
+Once the device is started, it will start searching for the suit until it finds all the sensor. You can check the output of the device to follow the status of the search. It may be required to move the sensor in order to let them be discovered.
 
 **Before running**
 Before running the device make sure that:
@@ -17,11 +17,11 @@ Before running the device make sure that:
   - `xsens-rundeps-dir`: Folder where XsensMVN runtime dependencies are stored.
   - `default-calibration-type`: Calibration type to be used (available values: `NposeWalk`, `TposeWalk`, `Npose`, `Tpose`).
   - `minimum-calibration-quality-required`: Minimum calibration quality to be considered good enought to be applied and allow the acquisition to start (available values: `Poor`, `Acceptable`, `Good`).
-  - `body-dimensions`: Subject=specific body dimensions.
+  - `body-dimensions`: Subject specific body dimensions.
 - The subject is wearing the suit correctly 
 
 **Calibration**
-In order to acquire data from the Xsens suit it is required to perform a calibration procedure, the type of procedure is set trought the configuration file (`default-calibration-type`).
+In order to acquire data from the Xsens suit it is required to perform a calibration procedure, the type of procedure is set through the configuration file (`default-calibration-type`).
 The calibration is started sending the following command:
 ```
 yarp rpc /XsensSuit/Control/rpc:i
@@ -44,5 +44,5 @@ startAcquisition
 ```
 If the device is running correctly, the stream of wearable data can be read with:
 ```
-/XsensSuit/WearableData/data:o
+yarp read ... /XsensSuit/WearableData/data:o
 ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,9 @@
+## Documentation
+
+Guidelines on how to run and use wearable sensor source devices.
+
+### Available documentation
+
+- [How-to-run-FTshoes](How-to-run-FTshoes.md)
+
+- [How-to-run-XsensSuit](How-to-run-XsensSuit.md)


### PR DESCRIPTION
With this PR I am adding some documentation on how to run some wearable devices.
This documentation is an updated version of the older documentation contained in https://github.com/robotology/human-dynamics-estimation/wiki/Human-Dynamics-Estimation-IWear-Source-Devices, in this way we also separate the documentation for the two repo and we can remove old documentation.

@Yeshasvitvs @diegoferigo 