### PR TITLE
Add wearable data dumper application

### DIFF
--- a/app/xml/applications/WearableDevices-Dumper.xml
+++ b/app/xml/applications/WearableDevices-Dumper.xml
@@ -1,0 +1,57 @@
+<application>
+  <name>WearableDevices-Dumper</name>
+  <description>An application for dumping wearable data</description>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /wearableData/FTshoes/left --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /wearableData/FTshoes/right --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /wearableData/xsens --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+      <name>yarpdatadumper</name>
+      <parameters>--name /wearableData/SkinInsoles --type bottle --txTime --rxTime</parameters>
+      <node>${generic_node}</node>
+      <tag>yarpdatadumper</tag>
+  </module>
+
+  <connection>
+        <from>/FTShoeLeft/WearableData/data:o</from>
+        <to>/wearableData/FTshoes/left</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/FTShoeRight/WearableData/data:o</from>
+        <to>/wearableData/FTshoes/right</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/XSensSuit/WearableData/data:o</from>
+        <to>/wearableData/xsens</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/SkinInsoles/WearableData/data:o</from>
+        <to>/wearableData/SkinInsoles</to>
+        <protocol>udp</protocol>
+  </connection>
+
+</application>


### PR DESCRIPTION
This PR add an application for dumping the wearable data with the objective of trying to take out wearable related applications from [HDE applications](https://github.com/robotology/human-dynamics-estimation/tree/master/conf/xml/applications) in order to clean it up.