### PR TITLE
Fix sampling-rate passing trough configuration

### DIFF
--- a/devices/XsensSuit/src/XsensSuit.cpp
+++ b/devices/XsensSuit/src/XsensSuit.cpp
@@ -723,7 +723,7 @@ bool XsensSuit::open(yarp::os::Searchable& config)
         yWarning() << logPrefix << "Using highest supported sampling rate";
     }
     else {
-        scanTimeout = config.find("sampling-rate").asInt();
+        samplingRate = config.find("sampling-rate").asInt();
     }
 
     // Get subject-specific body dimensions from the configuration file and push them to


### PR DESCRIPTION
as noticed in https://github.com/robotology/wearables/issues/40#issuecomment-555006582 the value passed trough configuration was actually not used.