### PR TITLE
Add wearable yarp dumper application to run HDE offline

### DIFF
--- a/app/xml/applications/HumanDynamicsEstimation-WearableDumper.xml
+++ b/app/xml/applications/HumanDynamicsEstimation-WearableDumper.xml
@@ -1,0 +1,46 @@
+<application>
+    <name>HumanDumper</name>
+    <description>Dumper for Wearable Data to run Human Dynamics Estimation</description>
+
+	<var name="generic_node">localhost</var>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/wearable/FTshoes/left --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/wearable/FTshoes/right --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <module>
+        <name>yarpdatadumper</name>
+        <parameters>--name /human_dump/wearable/xsens --type bottle --txTime --rxTime</parameters>
+        <node>${generic_node}</node>
+        <tag>yarpdatadumper</tag>
+  </module>
+
+  <connection>
+        <from>/FTShoeLeft/WearableData/data:o</from>
+        <to>/human_dump/wearable/FTshoes/left</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/FTShoeRight/WearableData/data:o</from>
+        <to>/human_dump/wearable/FTshoes/right</to>
+        <protocol>udp</protocol>
+  </connection>
+
+  <connection>
+        <from>/XSensSuit/WearableData/data:o</from>
+        <to>/human_dump/wearable/xsens</to>
+        <protocol>udp</protocol>
+  </connection>
+
+</application>


### PR DESCRIPTION
This PR adds a yarp manager application configuration file to save Xsens suit and FTShoes wearable data through yarp data daumper, to run human dynamics estimation tests offline.
