### PR TITLE
Cleanup plugin headers and IWear interface warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - FTShoes configuration files have been cleaned (https://github.com/robotology/wearables/pull/97)
+- Cleanup: (https://github.com/robotology/wearables/pull/99)
+    - Updated `yarp_prepare_plugin` header file path
+    - Added cmake policy to handle `IWear` interface relative path warning
 
 ## [1.1.0] - 2020-01-28
 

--- a/devices/IAnalogSensorToIWear/CMakeLists.txt
+++ b/devices/IAnalogSensorToIWear/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(ianalogsensor_to_iwear
     TYPE wearable::devices::IAnalogSensorToIWear
-    INCLUDE IAnalogSensorToIWear.h
+    INCLUDE include/IAnalogSensorToIWear.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)

--- a/devices/ICub/CMakeLists.txt
+++ b/devices/ICub/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(icub_wearable_device
     TYPE wearable::devices::ICub
-    INCLUDE ICub.h
+    INCLUDE include/ICub.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)

--- a/devices/IWearRemapper/CMakeLists.txt
+++ b/devices/IWearRemapper/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(iwear_remapper
     TYPE wearable::devices::IWearRemapper
-    INCLUDE IWearRemapper.h
+    INCLUDE include/IWearRemapper.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)

--- a/devices/Paexo/CMakeLists.txt
+++ b/devices/Paexo/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Compile the plugin by default
 yarp_prepare_plugin(paexo  TYPE wearable::devices::Paexo
-                    INCLUDE Paexo.h
+                    INCLUDE include/Paexo.h
                     CATEGORY device
                     ADVANCED
                     DEFAULT ON

--- a/devices/XsensSuit/CMakeLists.txt
+++ b/devices/XsensSuit/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(xsens_suit
     TYPE wearable::devices::XsensSuit
-    INCLUDE XsensSuit.h
+    INCLUDE include/XsensSuit.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)

--- a/interfaces/IWear/CMakeLists.txt
+++ b/interfaces/IWear/CMakeLists.txt
@@ -11,6 +11,10 @@ include(GNUInstallDirs)
 # IWEAR INTERFACE
 # ===============
 
+# Policy to suppress An interface source of target "IWear" has a relative path warning
+# Policy CMP0076 is not set: target_sources() command converts relative pathsto absolute.
+cmake_policy(SET CMP0076 OLD)
+
 # Group files with the correct path for the target_sources command
 file(GLOB_RECURSE IWEAR_HEADERS_BUILD include/*.h)
 file(GLOB_RECURSE IWEAR_HEADERS_INSTALL

--- a/wrappers/IWear/CMakeLists.txt
+++ b/wrappers/IWear/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(iwear_wrapper
     TYPE wearable::wrappers::IWearWrapper
-    INCLUDE IWearWrapper.h
+    INCLUDE include/IWearWrapper.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)

--- a/wrappers/IXsensMVNControl/CMakeLists.txt
+++ b/wrappers/IXsensMVNControl/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 yarp_prepare_plugin(ixsensmvncontrol_wrapper
     TYPE wearable::wrappers::IXsensMVNControlWrapper
-    INCLUDE IXsensMVNControlWrapper.h
+    INCLUDE include/IXsensMVNControlWrapper.h
     CATEGORY device
     ADVANCED
     DEFAULT ON)


### PR DESCRIPTION
This patch addresses the following two compile time warnings:

-  `yarp_prepare_plugin` header file path
- `IWear` interface relative path to files

![Screenshot from 2020-12-04 11-40-37](https://user-images.githubusercontent.com/6505998/101155431-6a4d3000-3627-11eb-9812-ec4ad5d4fc2e.png)


The patch results in clean compilation 

![Screenshot from 2020-12-04 11-48-17](https://user-images.githubusercontent.com/6505998/101155461-79cc7900-3627-11eb-9ce2-a09116055ec5.png)
