### PR TITLE
Do not overwrite default linker flags so that LDFLAGS environment variable is considered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+  - Fixed linking-related bug in the CMake build system that ignored the `LDFLAGS`  environment variable, breaking the build on some environments (https://github.com/robotology/wearables/pull/110).
+
 ## [1.2.0] - 2021-01-25
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ include(InstallBasicPackageFiles)
 if(UNIX AND NOT APPLE)
     get_filename_component(LINKER_BIN ${CMAKE_LINKER} NAME)
     if(${LINKER_BIN} STREQUAL "ld")
-        set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--unresolved-symbols=report-all")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--unresolved-symbols=report-all")
     endif()
 endif()
 


### PR DESCRIPTION
If one wants to specify additional linked flags, those should be appended to [`CMAKE_SHARED_LINKER_FLAGS`](https://cmake.org/cmake/help/latest/variable/CMAKE_SHARED_LINKER_FLAGS.html), not overwrite it as this would lead to the [`LDFLAGS`  environment variable](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) to be ignored, leading to linking errors in some environments (for example conda).

For more details see:
* https://github.com/osrf/gazebo/pull/2922
* https://github.com/robotology/robotology-superbuild/issues/681#issuecomment-817274209

It would be convenient to tag a released after this fix is integrated to fix the conda binary generation at the robotology-superbuild level (see  https://github.com/robotology/robotology-superbuild/issues/681). Let me know if you want to do that or you like me to do it.

Fix https://github.com/robotology/robotology-superbuild/issues/681 .

