### PR TITLE
Add iwear_logger wrapper device and AddInstallRPathSupport cmake module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ on:
     # * is a special character in YAML so you have to quote this string
     # Execute a "nightly" build at 2 AM UTC
     - cron: '0 2 * * *'
-    
+
 env:
     vcpkg_robotology_TAG: v0.5.0
     YCM_TAG: v0.12.0
     YARP_TAG: v3.4.1
-    iDynTree_TAG: v2.0.0   
+    iDynTree_TAG: v2.0.0
+    matioCpp_TAG: v0.1.1
     # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by Github Actions to point to our vcpkg
     VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
-    
+
 jobs:
     build:
         name: '[${{matrix.os}}@${{matrix.build_type}}]'
@@ -29,24 +30,24 @@ jobs:
                 build_type: [Release]
                 os: [ubuntu-latest, windows-latest, macOS-latest]  
             fail-fast: false
-                
+
         steps:
         # Clone the repository in $GITHUB_WORKSPACE
         - uses: actions/checkout@master  
-        
+
         # Print the environment variables to simplify development and debugging
         - name: Environment Variables
         # Use bash  in order to have same basic commands in all OSs
           shell: bash
           run: env
-          
+
         # Remove apt repos on Ubuntu that are known to break from time to time 
         # See https://github.com/actions/virtual-environments/issues/323 
         - name: Remove broken apt repos [Ubuntu]
           if: matrix.os == 'ubuntu-latest'
           run: |
             for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-        
+
         # ============
         # DEPENDENCIES
         # ============
@@ -61,11 +62,11 @@ jobs:
             wget https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/releases/download/${env:vcpkg_robotology_TAG}/vcpkg-robotology.zip
             unzip vcpkg-robotology.zip -d C:/
             rm vcpkg-robotology.zip
-               
+
         - name: Dependencies [macOS]
           if: matrix.os == 'macOS-latest'
           run: |
-            brew install ccache eigen ace tinyxml gsl
+            brew install ccache eigen ace tinyxml gsl boost libmatio
              
         - name: Dependencies [Ubuntu]
           if: matrix.os == 'ubuntu-latest'
@@ -73,16 +74,16 @@ jobs:
             sudo apt update
             sudo apt install git build-essential cmake libace-dev coinor-libipopt-dev  libboost-system-dev libboost-filesystem-dev \
                              libboost-thread-dev liborocos-kdl-dev libeigen3-dev swig qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libqt5charts5-dev \
-                             libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev
-                             
+                             libxml2-dev liburdfdom-dev libtinyxml-dev liburdfdom-dev liboctave-dev python-dev valgrind libassimp-dev libmatio-dev
+
         - name: Cache Source-based dependencies
           id: cache-source-deps
           uses: actions/cache@v1
           with:
             path: ${{ github.workspace }}/install/deps
             # Including ${{ runner.temp }} is a workaround for https://github.com/robotology/whole-body-estimators/issues/60
-            key: source-deps-${{runner.os}}-${{runner.temp}}-vcpkg-robotology-${{env.vcpkg_robotology_TAG}}-ycm-${{env.YCM_TAG}}-yarp-${{env.YARP_TAG}}-iDynTree-${{env.iDynTree_TAG}}
-                                                        
+            key: source-deps-${{runner.os}}-${{runner.temp}}-vcpkg-robotology-${{env.vcpkg_robotology_TAG}}-ycm-${{env.YCM_TAG}}-yarp-${{env.YARP_TAG}}-iDynTree-${{env.iDynTree_TAG}}-matioCpp-${{env.matioCpp_TAG}}-yarp_telemetry
+
         - name: Source-based Dependencies [Windows]
           if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
           shell: bash
@@ -96,7 +97,7 @@ jobs:
             cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
                          -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
-             
+
             # YARP
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/yarp
@@ -123,8 +124,32 @@ jobs:
                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                          -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target INSTALL
-                           
-             
+
+            # matioCpp
+            cd ${GITHUB_WORKSPACE}
+            git clone https://github.com/dic-iit/matio-cpp
+            cd matio-cpp
+            git checkout ${matioCpp_TAG}
+            mkdir -p build
+            cd build
+            cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                         -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+            cmake --build . --config ${{matrix.build_type}} --target INSTALL
+
+            # yarp-telemetry
+            cd ${GITHUB_WORKSPACE}
+            git clone https://github.com/robotology/yarp-telemetry
+            cd yarp-telemetry
+            mkdir -p build
+            cd build
+            cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake \
+                         -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                         -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
+                         -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+            cmake --build . --config ${{matrix.build_type}} --target INSTALL
+
         - name: Source-based Dependencies [Ubuntu/macOS]
           if: steps.cache-source-deps.outputs.cache-hit != 'true' && (matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest')
           shell: bash
@@ -137,7 +162,7 @@ jobs:
             cd build
             cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
-             
+
             # YARP
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/yarp
@@ -148,7 +173,7 @@ jobs:
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
-            
+
             # iDynTree
             cd ${GITHUB_WORKSPACE}
             git clone https://github.com/robotology/iDynTree
@@ -159,7 +184,28 @@ jobs:
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
             cmake --build . --config ${{matrix.build_type}} --target install
-              
+
+            # matioCpp
+            cd ${GITHUB_WORKSPACE}
+            git clone https://github.com/dic-iit/matio-cpp
+            cd matio-cpp
+            git checkout ${matioCpp_TAG}
+            mkdir -p build
+            cd build
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+            cmake --build . --config ${{matrix.build_type}} --target install
+
+            # yarp-telemetry
+            cd ${GITHUB_WORKSPACE}
+            git clone https://github.com/robotology/yarp-telemetry
+            cd yarp-telemetry
+            mkdir -p build
+            cd build
+            cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+                  -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install/deps ..
+            cmake --build . --config ${{matrix.build_type}} --target install
+
         # ===================
         # CMAKE-BASED PROJECT
         # ===================
@@ -176,7 +222,7 @@ jobs:
                          -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                          -DXSENS_MVN_USE_SDK:BOOL=OFF \
                          -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
-            
+
         - name: Configure [Ubuntu/macOS]
           if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
           shell: bash
@@ -185,7 +231,7 @@ jobs:
             cd build
             cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                   -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
-        
+
         # Build step          
         - name: Build
           shell: bash
@@ -195,5 +241,5 @@ jobs:
             # See https://github.com/robotology/idyntree/issues/569
             export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${VCPKG_INSTALLATION_ROOT}/install/x64-windows/bin:${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/debug/bin
             cmake --build . --config ${{matrix.build_type}}
-            
-                    
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.1] - 2021-04-12
 
+### Added
+- Added `iwear_logger` wrapper device to log wearable sensors data using `yarp-telemetry`. (https://github.com/robotology/wearables/pull/113)
+- Added `AddInstallRPATHSupport` cmake module for linking shared objects of private dependencies. (https://github.com/robotology/wearables/pull/113)
+
 ### Fixed
   - Fixed linking-related bug in the CMake build system that ignored the `LDFLAGS`  environment variable, breaking the build on some environments (https://github.com/robotology/wearables/pull/110).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
+# Enable RPATH support for installed binaries and libraries
+include(AddInstallRPATHSupport)
+add_install_rpath_support(LIB_DIRS "${CMAKE_INSTALL_FULL_LIBDIR}"       # Libraries
+                          BIN_DIRS "${CMAKE_INSTALL_FULL_BINDIR}"       # Binaries
+                                   "${CMAKE_INSTALL_FULL_LIBDIR}/yarp"  # Plugins
+                          INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}"
+                          USE_LINK_PATH)
+
 include(InstallBasicPackageFiles)
 
 # Tweak linker flags in Linux

--- a/app/xml/iWearLoggerExampleTemplate.xml
+++ b/app/xml/iWearLoggerExampleTemplate.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+<robot name="robot-name" build=0 portprefix="">
+    <!--Producer Device -->
+    <device type="producer_name" name="ProducerDevice">
+        <!-- producer parameters go here -->
+    </device>
+    
+    <device type="iwear_logger" name="ProducerLoggerDevice">
+        <param name="period">0.01</param>
+        
+        <param name="logAllQuantities">false</param>
+        <param name="logAccelerometers">false</param>
+        <param name="logEMGSensors">false</param>
+        <param name="logForce3DSensors">false</param>
+        <param name="logForceTorque6DSensors">true</param>
+        <param name="logFreeBodyAccelerationSensors">true</param>
+        <param name="logGyroscopes">true</param>
+        <param name="logMagnetometers">false</param>
+        <param name="logOrientationSensors">true</param>
+        <param name="logPoseSensors">false</param>
+        <param name="logPositionSensors">false</param>
+        <param name="logTemperatureSensors">false</param>
+        <param name="logTorque3DSensors">false</param>
+        <param name="logVirtualLinkKinSensors">false</param>
+        <param name="logVirtualJointKinSensors">false</param>
+        <param name="logVirtualSphericalJointKinSensors">false</param>                
+        
+        <param name="saveBufferManagerConfiguration">true</param>
+        <param name="experimentName">test_iwear_logger</param>
+        <param name="path">/path/to/some/folder/</param>
+        <param name="n_samples">100000</param>
+        <param name="save_periodically">true</param>
+        <param name="save_period">120.0</param>
+        <param name="data_threshold">300</param>
+        <param name="auto_save">true</param>
+
+        <action phase="startup" level="5" type="attach">
+            <paramlist name="networks">
+            	<!-- attach the source device here -->
+                <elem name="ProducerDeviceWrapperLabel"> ProducerDevice </elem>
+            </paramlist>
+        </action>
+        <action phase="shutdown" level="5" type="detach"/>
+    </device>
+
+</robot>
+

--- a/cmake/AddInstallRPATHSupport.cmake
+++ b/cmake/AddInstallRPATHSupport.cmake
@@ -1,0 +1,237 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+AddInstallRPATHSupport
+----------------------
+
+Add support to RPATH during installation to the project and the targets
+
+.. command:: add_install_rpath_support
+
+  Add support to RPATH during installation to the project::
+
+  .. code-block:: cmake
+
+    add_install_rpath_support([BIN_DIRS dir [dir]]
+                              [LIB_DIRS dir [dir]]
+                              [INSTALL_NAME_DIR [dir]]
+                              [DEPENDS condition [condition]]
+                              [USE_LINK_PATH])
+
+  Normally (depending on the platform) when you install a shared
+  library you can either specify its absolute path as the install name,
+  or leave just the library name itself. In the former case the library
+  will be correctly linked during run time by all executables and other
+  shared libraries, but it must not change its install location. This
+  is often the case for libraries installed in the system default
+  library directory (e.g. ``/usr/lib``).
+  In the latter case, instead, the library can be moved anywhere in the
+  file system but at run time the dynamic linker must be able to find
+  it. This is often accomplished by setting environmental variables
+  (i.e. ``LD_LIBRARY_PATH`` on Linux).
+  This procedure is usually not desirable for two main reasons:
+
+  - by setting the variable you are changing the default behaviour
+    of the dynamic linker thus potentially breaking executables (not as
+    destructive as ``LD_PRELOAD``)
+  - the variable will be used only by applications spawned by the shell
+    and not by other processes.
+
+  RPATH aims in solving the issues introduced by the second
+  installation method. Using run-path dependent libraries you can
+  create a directory structure containing executables and dependent
+  libraries that users can relocate without breaking it.
+  A run-path dependent library is a dependent library whose complete
+  install name is not known when the library is created.
+  Instead, the library specifies that the dynamic loader must resolve
+  the library’s install name when it loads the executable that depends
+  on the library. The executable or the other shared library will
+  hardcode in the binary itself the additional search directories
+  to be passed to the dynamic linker. This works great in conjunction
+  with relative paths.
+  This command will enable support to RPATH to your project.
+  It will enable the following things:
+
+   - If the project builds shared libraries it will generate a run-path
+     enabled shared library, i.e. its install name will be resolved
+     only at run time.
+   - In all cases (building executables and/or shared libraries)
+     dependent shared libraries with RPATH support will have their name
+     resolved only at run time, by embedding the search path directly
+     into the built binary.
+
+  The command has the following parameters:
+
+  Options:
+   - ``USE_LINK_PATH``: if passed the command will automatically adds to
+     the RPATH the path to all the dependent libraries.
+
+  Arguments:
+   - ``BIN_DIRS`` list of directories when the targets (executable and
+     plugins) will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``BIN_DIRS`` and
+     ``LIB_DIRS``.
+   - ``INSTALL_NAME_DIR`` directory where the libraries will be installed.
+     This variable will be used only if ``CMAKE_SKIP_RPATH`` or
+     ``CMAKE_SKIP_INSTALL_RPATH`` is set to ``TRUE`` as it will set the
+     ``INSTALL_NAME_DIR`` on all targets
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+  Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
+  details.
+
+.. command:: target_append_install_rpath
+
+  Add extra paths to RPATH for a specific target::
+
+  .. code-block:: cmake
+
+    target_append_install_rpath(<target>
+                                <INSTALL_DESTINATION destination>
+                                [LIB_DIRS dir [dir]]
+                                [DEPENDS condition [condition]])
+
+  Arguments:
+   - ``INSTALL_DESTINATION`` path where the target will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``INSTALL_DESTINATION``.
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
+#]=======================================================================]
+
+include(CMakeParseArguments)
+
+
+macro(__AddInstallRPATHSupport_GET_SYSTEM_LIB_DIRS _var)
+  # Find system implicit lib directories
+  set(${_var} ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
+  if(EXISTS "/etc/debian_version") # is this a debian system ?
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      list(APPEND ${_var} "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                          "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    endif()
+  endif()
+endmacro()
+
+
+macro(__AddInstallRPATHSupport_APPEND_RELATIVE_RPATH _var _bin_dir _lib_dir)
+  file(RELATIVE_PATH _rel_path ${_bin_dir} ${_lib_dir})
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(APPEND ${_var} "@loader_path/${_rel_path}")
+  else()
+    list(APPEND ${_var} "\$ORIGIN/${_rel_path}")
+  endif()
+endmacro()
+
+
+
+function(ADD_INSTALL_RPATH_SUPPORT)
+
+  set(_options USE_LINK_PATH)
+  set(_oneValueArgs INSTALL_NAME_DIR)
+  set(_multiValueArgs BIN_DIRS
+                      LIB_DIRS
+                      DEPENDS)
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  # if either RPATH or INSTALL_RPATH is disabled
+  # and the INSTALL_NAME_DIR variable is set, then hardcode the install name
+  if(CMAKE_SKIP_RPATH OR CMAKE_SKIP_INSTALL_RPATH)
+    if(DEFINED _ARS_INSTALL_NAME_DIR)
+      set(CMAKE_INSTALL_NAME_DIR ${_ARS_INSTALL_NAME_DIR} PARENT_SCOPE)
+    endif()
+  endif()
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    # Enable RPATH on OSX.
+    set(CMAKE_MACOSX_RPATH TRUE PARENT_SCOPE)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    # This is relative RPATH for libraries built in the same project
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        foreach(bin_dir ${_ARS_LIB_DIRS} ${_ARS_BIN_DIRS})
+          __AddInstallRPATHSupport_append_relative_rpath(CMAKE_INSTALL_RPATH ${bin_dir} ${lib_dir})
+        endforeach()
+      endif()
+    endforeach()
+    if(NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "")
+      list(REMOVE_DUPLICATES CMAKE_INSTALL_RPATH)
+    endif()
+    set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_RPATH} PARENT_SCOPE)
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ${_ARS_USE_LINK_PATH} PARENT_SCOPE)
+
+  endif()
+
+endfunction()
+
+
+function(TARGET_APPEND_INSTALL_RPATH _target)
+  set(_options )
+  set(_oneValueArgs INSTALL_DESTINATION)
+  set(_multiValueArgs LIB_DIRS
+                      DEPENDS)
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    get_target_property(_current_rpath ${_target} INSTALL_RPATH)
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        __AddInstallRPATHSupport_append_relative_rpath(_current_rpath ${_ARS_INSTALL_DESTINATION} ${lib_dir})
+      endif()
+    endforeach()
+    set_target_properties(${_target} PROPERTIES INSTALL_RPATH "${_current_rpath}")
+  endif()
+
+endfunction()

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -5,3 +5,5 @@
 add_subdirectory(IWear)
 add_subdirectory(IWearActuators)
 add_subdirectory(IXsensMVNControl)
+add_subdirectory(IWearLogger)
+

--- a/wrappers/IWearLogger/CMakeLists.txt
+++ b/wrappers/IWearLogger/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (C) 2018-2021 Istituto Italiano di Tecnologia (IIT). All rights reserved.
+# This software may be modified and distributed under the terms of the
+# GNU Lesser General Public License v2.1 or any later version.
+
+find_package(YARP COMPONENTS telemetry dev QUIET)
+
+if (${YARP_FOUND})
+
+yarp_prepare_plugin(iwear_logger
+    TYPE wearable::wrappers::IWearLogger
+    INCLUDE include/IWearLogger.h
+    CATEGORY device
+    ADVANCED
+    DEFAULT ON)
+
+yarp_add_plugin(IWearLogger
+    src/IWearLogger.cpp
+    include/IWearLogger.h)
+
+target_include_directories(IWearLogger PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+target_link_libraries(IWearLogger PUBLIC
+    IWear WearableData YARP::YARP_dev YARP::YARP_telemetry)
+
+yarp_install(
+    TARGETS IWearLogger
+    COMPONENT runtime
+    LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
+    ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
+    YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
+
+endif()
+

--- a/wrappers/IWearLogger/include/IWearLogger.h
+++ b/wrappers/IWearLogger/include/IWearLogger.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#ifndef IWEARLOGGER_H
+#define IWEARLOGGER_H
+
+#include <memory>
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/Wrapper.h>
+#include <yarp/os/PeriodicThread.h>
+
+namespace wearable {
+    namespace wrappers {
+        class IWearLogger;
+    }
+} // namespace wearable
+
+class wearable::wrappers::IWearLogger
+    : public yarp::dev::DeviceDriver
+    , public yarp::dev::IWrapper
+    , public yarp::dev::IMultipleWrapper
+    , public yarp::os::PeriodicThread
+{
+private:
+    class impl;
+    std::unique_ptr<impl> pImpl;
+
+public:
+    IWearLogger();
+    ~IWearLogger() override;
+
+    // PeriodicThread
+    void run() override;
+    void threadRelease() override;
+
+    // DeviceDriver interface
+    bool open(yarp::os::Searchable& config) override;
+    bool close() override;
+
+    // IWrapper interface
+    bool attach(yarp::dev::PolyDriver* poly) override;
+    bool detach() override;
+
+    // IMultipleWrapper interface
+    bool attachAll(const yarp::dev::PolyDriverList& driverList) override;
+    bool detachAll() override;
+};
+
+#endif // IWEARLOGGER_H

--- a/wrappers/IWearLogger/src/IWearLogger.cpp
+++ b/wrappers/IWearLogger/src/IWearLogger.cpp
@@ -1,0 +1,927 @@
+/*
+ * Copyright (C) 2018-2021 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * GNU Lesser General Public License v2.1 or any later version.
+ */
+
+#include "IWearLogger.h"
+#include "Wearable/IWear/IWear.h"
+
+#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/os/LogStream.h>
+#include <mutex>
+#include <vector>
+#include <algorithm>
+#include <functional>
+
+
+#include <yarp/telemetry/experimental/BufferManager.h>
+
+const std::string WrapperName = "IWearLogger";
+const std::string logPrefix = WrapperName + " :";
+constexpr double DefaultPeriod = 0.01;
+
+namespace wearable {
+    namespace wrappers {
+        struct IWearLoggerSettings;
+    }
+}
+struct wearable::wrappers::IWearLoggerSettings
+{
+    bool saveBufferManagerConfiguration{false};
+    bool logAllQuantities{false};
+    bool logAccelerometers{false};
+    bool logEMGSensors{false};
+    bool logForce3DSensors{false};
+    bool logForceTorque6DSensors{false};
+    bool logFreeBodyAccelerationSensors{false};
+    bool logGyroscopes{false};
+    bool logMagnetometers{false};
+    bool logOrientationSensors{false};
+    bool logPoseSensors{false};
+    bool logPositionSensors{false};
+    bool logTemperatureSensors{false};
+    bool logTorque3DSensors{false};
+    bool logVirtualLinkKinSensors{false};
+    bool logVirtualJointKinSensors{false};
+    bool logVirtualSphericalJointKinSensors{false};
+
+    // skin sensors are not currently supported
+};
+
+
+using namespace wearable;
+using namespace wearable::wrappers;
+
+class IWearLogger::impl
+{
+public:
+    bool loadSettingsFromConfig(yarp::os::Searchable& config);
+    void checkAndLoadBooleanOption(yarp::os::Property& prop,
+                                   const std::string& optionName,
+                                   bool& option);
+    bool configureBufferManager();
+
+    inline std::vector<std::string> split (const std::string& s, const std::string& delimiter)
+    {
+        std::size_t pos_start = 0, pos_end, delim_len = delimiter.length();
+        std::string token;
+        std::vector<std::string> res;
+
+        while ((pos_end = s.find (delimiter, pos_start)) != std::string::npos) {
+            token = s.substr (pos_start, pos_end - pos_start);
+            pos_start = pos_end + delim_len;
+            res.push_back (token);
+        }
+
+        res.push_back (s.substr (pos_start));
+        return res;
+    }
+
+    inline std::string convertSensorNameToValidMatlabVarName(const std::string& sensorName)
+    {
+        std::string matlabName{sensorName};
+        // replace special characters with underscore
+        std::replace(matlabName.begin(), matlabName.end(), '#', '_');
+        std::replace(matlabName.begin(), matlabName.end(), '@', '_');
+        std::replace(matlabName.begin(), matlabName.end(), '/', '_');
+        std::replace(matlabName.begin(), matlabName.end(), '(', '_');
+        std::replace(matlabName.begin(), matlabName.end(), ')', '_');
+
+        auto vecStr = split(matlabName, wearable::Separator);
+        std::string validMatlabName;
+        for (auto& str : vecStr)
+        {
+            if (validMatlabName.empty())
+            {
+                validMatlabName = str;
+            }
+            else
+            {
+                validMatlabName  = validMatlabName+ "_"+str;
+            }
+        }
+        return validMatlabName;
+    }
+
+    inline void prefixVecWithSensorStatus(const std::shared_ptr<const wearable::sensor::ISensor>& sensor,
+                                          std::vector<double>& saveVar)
+    {
+        // prefix sensor status
+        auto it = saveVar.begin();
+        saveVar.insert(it, static_cast<double>(sensor->getSensorStatus()));
+    }
+
+    bool firstRun = true;
+    size_t waitingFirstReadCounter = 1;
+
+    wearable::IWear* iWear = nullptr;
+    yarp::dev::IPreciselyTimed* iPreciselyTimed = nullptr;
+    std::mutex loggerMutex;
+    IWearLoggerSettings settings;
+    yarp::telemetry::experimental::BufferConfig bufferConfig;
+    yarp::telemetry::experimental::BufferManager<double> bufferManager;
+
+    wearable::VectorOfSensorPtr<const wearable::sensor::IAccelerometer> accelerometers;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IEmgSensor> emgSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IForce3DSensor> force3DSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IForceTorque6DSensor> forceTorque6DSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IFreeBodyAccelerationSensor>
+        freeBodyAccelerationSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IGyroscope> gyroscopes;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IMagnetometer> magnetometers;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IOrientationSensor> orientationSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IPoseSensor> poseSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IPositionSensor> positionSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::ITemperatureSensor> temperatureSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::ITorque3DSensor> torque3DSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IVirtualLinkKinSensor>
+        virtualLinkKinSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IVirtualJointKinSensor>
+        virtualJointKinSensors;
+    wearable::VectorOfSensorPtr<const wearable::sensor::IVirtualSphericalJointKinSensor>
+        virtualSphericalJointKinSensors;
+
+    std::unordered_map<std::string, std::string> wearable2MatlabNameLookup;
+};
+
+IWearLogger::IWearLogger()
+    : yarp::os::PeriodicThread(DefaultPeriod)
+    , pImpl{new impl()}
+{}
+
+IWearLogger::~IWearLogger()
+{
+    detachAll();
+    close();
+}
+
+// ========================
+// PeriodicThread interface
+// ========================
+
+void IWearLogger::run()
+{
+    if (!pImpl->iWear) {
+        yError() << logPrefix << "The IWear pointer is null in the driver loop.";
+        askToStop();
+        return;
+    }
+
+    if (!pImpl->iPreciselyTimed) {
+        yError() << logPrefix << "The IPreciselyTimed pointer is null in the driver loop.";
+        askToStop();
+        return;
+    }
+
+    while (pImpl->iWear->getStatus() == WearStatus::Calibrating
+           || pImpl->iWear->getStatus() == WearStatus::WaitingForFirstRead) {
+        if (pImpl->waitingFirstReadCounter++ % 1000 == 0) {
+            pImpl->waitingFirstReadCounter = 1;
+            yInfo() << logPrefix << "IWear interface waiting for first data. Waiting...";
+        }
+        return;
+    }
+
+    if (pImpl->iWear->getStatus() == WearStatus::Error
+            || pImpl->iWear->getStatus() == WearStatus::Unknown) {
+        yError() << logPrefix << "The status of the IWear interface is not Ok ("
+                 << static_cast<int>(pImpl->iWear->getStatus()) << ")";
+        askToStop();
+        return;
+    }
+
+    // case status is TIMEOUT or DATA_OVERFLOW
+    if (pImpl->iWear->getStatus() != WearStatus::Ok) {
+        yWarning() << logPrefix << "The status of the IWear interface is not Ok ("
+                 << static_cast<int>(pImpl->iWear->getStatus()) << ")";
+    }
+
+    if (pImpl->firstRun) {
+        pImpl->firstRun = false;
+        pImpl->accelerometers = pImpl->iWear->getAccelerometers();
+        pImpl->emgSensors = pImpl->iWear->getEmgSensors();
+        pImpl->force3DSensors = pImpl->iWear->getForce3DSensors();
+        pImpl->forceTorque6DSensors = pImpl->iWear->getForceTorque6DSensors();
+        pImpl->freeBodyAccelerationSensors = pImpl->iWear->getFreeBodyAccelerationSensors();
+        pImpl->gyroscopes = pImpl->iWear->getGyroscopes();
+        pImpl->magnetometers = pImpl->iWear->getMagnetometers();
+        pImpl->orientationSensors = pImpl->iWear->getOrientationSensors();
+        pImpl->poseSensors = pImpl->iWear->getPoseSensors();
+        pImpl->positionSensors = pImpl->iWear->getPositionSensors();
+        pImpl->temperatureSensors = pImpl->iWear->getTemperatureSensors();
+        pImpl->torque3DSensors = pImpl->iWear->getTorque3DSensors();
+        pImpl->virtualLinkKinSensors = pImpl->iWear->getVirtualLinkKinSensors();
+        pImpl->virtualJointKinSensors = pImpl->iWear->getVirtualJointKinSensors();
+        pImpl->virtualSphericalJointKinSensors = pImpl->iWear->getVirtualSphericalJointKinSensors();
+    }
+
+    yarp::os::Stamp timestamp = pImpl->iPreciselyTimed->getLastInputStamp();
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logAccelerometers)
+    {
+        for (const auto& sensor : pImpl->accelerometers) {
+            wearable::Vector3 vector3;
+            if (!sensor->getLinearAcceleration(vector3)) {
+                yWarning() << logPrefix << "[Accelerometers] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logEMGSensors)
+    {
+        for (const auto& sensor : pImpl->emgSensors) {
+            double value, normalization;
+            // double normalizationValue;
+            if (!sensor->getEmgSignal(value) || !sensor->getEmgSignal(normalization)) {
+                yWarning() << logPrefix << "[EmgSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar;
+                saveVar.emplace_back(value);
+                saveVar.emplace_back(normalization);
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logForce3DSensors)
+    {
+        for (const auto& sensor : pImpl->force3DSensors) {
+            wearable::Vector3 vector3;
+            if (!sensor->getForce3D(vector3)) {
+                yWarning() << logPrefix << "[Force3DSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is ";
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logForceTorque6DSensors)
+    {
+        for (const auto& sensor : pImpl->forceTorque6DSensors) {
+            wearable::Vector6 vector6;
+            if (!sensor->getForceTorque6D(vector6)) {
+                yWarning() << logPrefix << "[ForceTorque6DSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector6.begin(), vector6.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logFreeBodyAccelerationSensors)
+    {
+        for (const auto& sensor : pImpl->freeBodyAccelerationSensors) {
+            wearable::Vector3 vector3;
+            if (!sensor->getFreeBodyAcceleration(vector3)) {
+                yWarning() << logPrefix << "[FreeBodyAccelerationSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logGyroscopes)
+    {
+        for (const auto& sensor : pImpl->gyroscopes) {
+            wearable::Vector3 vector3;
+            if (!sensor->getAngularRate(vector3)) {
+                yWarning() << logPrefix << "[Gyroscopes] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logMagnetometers)
+    {
+        for (const auto& sensor : pImpl->magnetometers) {
+            wearable::Vector3 vector3;
+            if (!sensor->getMagneticField(vector3)) {
+                yWarning() << logPrefix << "[Magnetometers] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logOrientationSensors)
+    {
+        for (const auto& sensor : pImpl->orientationSensors) {
+            wearable::Quaternion quaternion;
+            if (!sensor->getOrientationAsQuaternion(quaternion)) {
+                yWarning() << logPrefix << "[OrientationSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{quaternion.begin(), quaternion.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logPoseSensors)
+    {
+        for (const auto& sensor : pImpl->poseSensors) {
+            wearable::Vector3 vector3;
+            wearable::Quaternion quaternion;
+            if (!sensor->getPose(quaternion, vector3)) {
+                yWarning() << logPrefix << "[PoseSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar;
+                std::copy(vector3.begin(), vector3.end(), std::back_inserter(saveVar));
+                std::copy(quaternion.begin(), quaternion.end(), std::back_inserter(saveVar));
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logPositionSensors)
+    {
+        for (const auto& sensor : pImpl->positionSensors) {
+            wearable::Vector3 vector3;
+            if (!sensor->getPosition(vector3)) {
+                yWarning() << logPrefix << "[PositionSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logTemperatureSensors)
+    {
+        for (const auto& sensor : pImpl->temperatureSensors) {
+            double value;
+            if (!sensor->getTemperature(value)) {
+                yWarning() << logPrefix << "[TemperatureSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar;
+                saveVar.emplace_back(value);
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logTorque3DSensors)
+    {
+        for (const auto& sensor : pImpl->torque3DSensors) {
+            wearable::Vector3 vector3;
+            if (!sensor->getTorque3D(vector3)) {
+                yWarning() << logPrefix << "[Torque3DSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar{vector3.begin(), vector3.end()};
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logVirtualLinkKinSensors)
+    {
+        for (const auto& sensor : pImpl->virtualLinkKinSensors) {
+            wearable::Vector3 linearAcc;
+            wearable::Vector3 angularAcc;
+            wearable::Vector3 linearVel;
+            wearable::Vector3 angularVel;
+            wearable::Vector3 position;
+            wearable::Quaternion orientation;
+            if (!sensor->getLinkAcceleration(linearAcc, angularAcc)
+                || !sensor->getLinkPose(position, orientation)
+                || !sensor->getLinkVelocity(linearVel, angularVel)) {
+                yWarning() << logPrefix << "[VirtualLinkKinSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar;
+                std::copy(position.begin(), position.end(), std::back_inserter(saveVar));
+                std::copy(orientation.begin(), orientation.end(), std::back_inserter(saveVar));
+                std::copy(linearVel.begin(), linearVel.end(), std::back_inserter(saveVar));
+                std::copy(angularVel.begin(), angularVel.end(), std::back_inserter(saveVar));
+                std::copy(linearAcc.begin(), linearAcc.end(), std::back_inserter(saveVar));
+                std::copy(angularAcc.begin(), angularAcc.end(), std::back_inserter(saveVar));
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logVirtualJointKinSensors)
+    {
+        for (const auto& sensor : pImpl->virtualJointKinSensors) {
+            double jointPos;
+            double jointVel;
+            double jointAcc;
+            if (!sensor->getJointPosition(jointPos) || !sensor->getJointVelocity(jointVel)
+                || !sensor->getJointAcceleration(jointAcc)) {
+                yError() << logPrefix << "[VirtualJointKinSensors] "
+                         << "Failed to read data";
+                askToStop();
+                return;
+            }
+            else {
+                std::vector<double> saveVar;
+                saveVar.emplace_back(jointPos);
+                saveVar.emplace_back(jointVel);
+                saveVar.emplace_back(jointAcc);
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+
+    if (pImpl->settings.logAllQuantities || pImpl->settings.logVirtualSphericalJointKinSensors)
+    {
+        for (const auto& sensor : pImpl->virtualSphericalJointKinSensors) {
+            wearable::Vector3 jointAngles;
+            wearable::Vector3 jointVel;
+            wearable::Vector3 jointAcc;
+            if (!sensor->getJointAnglesAsRPY(jointAngles) || !sensor->getJointVelocities(jointVel)
+                || !sensor->getJointAccelerations(jointAcc)) {
+                yWarning() << logPrefix << "[VirtualSphericalJointKinSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+            else {
+                std::vector<double> saveVar;
+                std::copy(jointAngles.begin(), jointAngles.end(), std::back_inserter(saveVar));
+                std::copy(jointVel.begin(), jointVel.end(), std::back_inserter(saveVar));
+                std::copy(jointAcc.begin(), jointAcc.end(), std::back_inserter(saveVar));
+                pImpl->prefixVecWithSensorStatus(sensor, saveVar);
+                const auto& channelName = pImpl->wearable2MatlabNameLookup.at(sensor->getSensorName());
+                pImpl->bufferManager.push_back(saveVar, timestamp.getTime(), channelName);
+            }
+        }
+    }
+}
+
+// ======================
+// DeviceDriver interface
+// ======================
+
+bool IWearLogger::open(yarp::os::Searchable& config)
+{
+    std::lock_guard<std::mutex> guard(pImpl->loggerMutex);
+    if (!config.check("period")) {
+        yInfo() << logPrefix << "Using default period: " << DefaultPeriod << "s";
+    }
+
+    const double period = config.check("period", yarp::os::Value(DefaultPeriod)).asFloat64();
+    setPeriod(period);
+
+    // Load settings in the class
+    bool ok = pImpl->loadSettingsFromConfig(config);
+    if (!ok)
+    {
+        yError() << logPrefix << "Problem in loading settings from config.";
+        return false;
+    }
+
+    return true;
+}
+
+bool IWearLogger::impl::loadSettingsFromConfig(yarp::os::Searchable& config)
+{
+    yarp::os::Property prop;
+    prop.fromString(config.toString().c_str());
+
+    // load logger flag settings
+    checkAndLoadBooleanOption(prop, "logAllQuantities", settings.logAllQuantities);
+    checkAndLoadBooleanOption(prop, "logAccelerometers", settings.logAccelerometers);
+    checkAndLoadBooleanOption(prop, "logEMGSensors", settings.logEMGSensors);
+    checkAndLoadBooleanOption(prop, "logForce3DSensors", settings.logForce3DSensors);
+    checkAndLoadBooleanOption(prop, "logForceTorque6DSensors", settings.logForceTorque6DSensors);
+    checkAndLoadBooleanOption(prop, "logFreeBodyAccelerationSensors", settings.logFreeBodyAccelerationSensors);
+    checkAndLoadBooleanOption(prop, "logGyroscopes", settings.logGyroscopes);
+    checkAndLoadBooleanOption(prop, "logMagnetometers", settings.logMagnetometers);
+    checkAndLoadBooleanOption(prop, "logOrientationSensors", settings.logOrientationSensors);
+    checkAndLoadBooleanOption(prop, "logPoseSensors", settings.logPoseSensors);
+    checkAndLoadBooleanOption(prop, "logPositionSensors", settings.logPositionSensors);
+    checkAndLoadBooleanOption(prop, "logTemperatureSensors", settings.logTemperatureSensors);
+    checkAndLoadBooleanOption(prop, "logTorque3DSensors", settings.logTorque3DSensors);
+    checkAndLoadBooleanOption(prop, "logVirtualLinkKinSensors", settings.logVirtualLinkKinSensors);
+    checkAndLoadBooleanOption(prop, "logVirtualJointKinSensors", settings.logVirtualJointKinSensors);
+    checkAndLoadBooleanOption(prop, "logVirtualSphericalJointKinSensors", settings.logVirtualSphericalJointKinSensors);
+
+    // load buffer manager configuration settings
+    checkAndLoadBooleanOption(prop, "saveBufferManagerConfiguration", settings.saveBufferManagerConfiguration);
+
+    std::string experimentName = "experimentName";
+    if (prop.check(experimentName.c_str()) && prop.find(experimentName.c_str()).isString()) {
+        bufferConfig.filename = prop.find(experimentName.c_str()).asString();
+    }
+    else {
+        yError() << logPrefix << " missing parameter: " << experimentName;
+        return false;
+    }
+
+    std::string path = "path";
+    if (prop.check(path.c_str()) && prop.find(path.c_str()).isString()) {
+        bufferConfig.path = prop.find(path.c_str()).asString();
+    }
+
+    std::string n_samples = "n_samples";
+    if (prop.check(n_samples.c_str()) && prop.find(n_samples.c_str()).isInt32()) {
+        bufferConfig.n_samples = prop.find(n_samples.c_str()).asInt32();
+    }
+    else {
+        yError() << logPrefix << " missing parameter: " << n_samples;
+        return false;
+    }
+
+    std::string save_periodically = "save_periodically";
+    if (prop.check(save_periodically.c_str()) && prop.find(save_periodically.c_str()).isBool()) {
+        bufferConfig.save_periodically = prop.find(save_periodically.c_str()).asBool();
+    }
+
+    if (bufferConfig.save_periodically) {
+        std::string save_period = "save_period";
+        if (prop.check(save_period.c_str()) && prop.find(save_period.c_str()).isFloat64()) {
+            bufferConfig.save_period = prop.find(save_period.c_str()).asFloat64();
+        }
+        else {
+            yError() << logPrefix << " missing parameter: " << save_period;
+            return false;
+        }
+
+        std::string data_threshold = "data_threshold";
+        if (prop.check(data_threshold.c_str()) && prop.find(data_threshold.c_str()).isInt32()) {
+            bufferConfig.data_threshold = prop.find(data_threshold.c_str()).asInt32();
+        }
+
+    }
+
+    std::string auto_save = "auto_save";
+    if (prop.check(auto_save.c_str()) && prop.find(auto_save.c_str()).isBool()) {
+        bufferConfig.auto_save = prop.find(auto_save.c_str()).asBool();
+    }
+
+    if (!(bufferConfig.auto_save || bufferConfig.save_periodically)) {
+        yError() << logPrefix << " both auto_save and save_periodically are set to false, nothing will be saved.";
+        return false;
+    }
+
+    return true;
+}
+
+void IWearLogger::impl::checkAndLoadBooleanOption(yarp::os::Property& prop,
+                                            const std::string& optionName,
+                                            bool& option)
+{
+    if (prop.check(optionName.c_str())) {
+        option = prop.find(optionName.c_str()).asBool();
+    }
+}
+
+bool IWearLogger::close()
+{
+    if (!pImpl->bufferConfig.auto_save)
+    {
+        pImpl->bufferManager.saveToFile();
+    }
+    bool ok{true};
+    if (pImpl->settings.saveBufferManagerConfiguration) {
+        auto buffConfToSave = pImpl->bufferManager.getBufferConfig();
+        ok = bufferConfigToJson(buffConfToSave, buffConfToSave.path + "bufferConfig" + buffConfToSave.filename + ".json");
+    }
+    return ok;
+}
+
+// ==================
+// IWrapper interface
+// ==================
+
+bool IWearLogger::attach(yarp::dev::PolyDriver* poly)
+{
+    if (!poly) {
+        yError() << logPrefix << "Passed PolyDriver is nullptr.";
+        return false;
+    }
+
+    if (pImpl->iWear || !poly->view(pImpl->iWear) || !pImpl->iWear) {
+        yError() << logPrefix << "Failed to view the IWear interface from the PolyDriver.";
+        return false;
+    }
+
+    if (pImpl->iPreciselyTimed || !poly->view(pImpl->iPreciselyTimed) || !pImpl->iPreciselyTimed) {
+        yError() << logPrefix
+                 << "Failed to view the IPreciselyTimed interface from the PolyDriver.";
+        return false;
+    }
+
+    if (!pImpl->configureBufferManager()) {
+        yError() << logPrefix << "Failed to configure buffer manager for the logger.";
+    }
+
+    // Start the PeriodicThread loop
+    if (!start()) {
+        yError() << logPrefix << "Failed to start the loop.";
+        return false;
+    }
+
+    yDebug() << logPrefix << "attach() successful";
+    return true;
+}
+
+bool IWearLogger::impl::configureBufferManager()
+{
+    bool ok{true};
+    // Prepare the buffer manager for the logger
+    if (ok && (settings.logAllQuantities || settings.logAccelerometers) ) {
+        for (const auto& s : iWear->getAccelerometers()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) accelerometer channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logEMGSensors) ) {
+        for (const auto& s : iWear->getEmgSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (3, 1) EMG sensor channels value+normalization for "
+            << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {3, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logForce3DSensors) ) {
+        for (const auto& s : iWear->getForce3DSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) 3d force sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logForceTorque6DSensors) ) {
+        for (const auto& s : iWear->getForceTorque6DSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (7, 1) 6D force torque sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {7, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logFreeBodyAccelerationSensors) ) {
+        for (const auto& s : iWear->getFreeBodyAccelerationSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) free body acceleration sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logGyroscopes) ) {
+        for (const auto& s : iWear->getGyroscopes()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) gyroscope channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logMagnetometers) ) {
+        for (const auto& s : iWear->getMagnetometers()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) magnetometer channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logOrientationSensors) ) {
+        for (const auto& s : iWear->getOrientationSensors()) {
+            std::string sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (5, 1) quaternion wxyz channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {5, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logPoseSensors) ) {
+        for (const auto& s : iWear->getPoseSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (8, 1) pose sensor (pos+quat) channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {8, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logPositionSensors) ) {
+        for (const auto& s : iWear->getPositionSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) pose sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logTemperatureSensors) ) {
+        for (const auto& s : iWear->getTemperatureSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (2, 1) temperature sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {2, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logTorque3DSensors) ) {
+        for (const auto& s : iWear->getTorque3DSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) 3D torque sensor channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logVirtualLinkKinSensors) ) {
+        for (const auto& s : iWear->getVirtualLinkKinSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (20, 1) pos+quat+v+omega+a+alpha channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {20, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logVirtualJointKinSensors) ) {
+        for (const auto& s : iWear->getVirtualJointKinSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (4, 1) virtual joint kinematics channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {4, 1}});
+        }
+    }
+
+    if (ok && (settings.logAllQuantities || settings.logVirtualSphericalJointKinSensors) ) {
+        for (const auto& s : iWear->getVirtualSphericalJointKinSensors()) {
+            auto sensorName = s->getSensorName();
+            yInfo() << logPrefix << "Adding (10, 1) rpy+vel+acc virtual spherical joint kinematics channels for "
+                    << sensorName << " prefixed with sensor status.";
+            auto channelName = convertSensorNameToValidMatlabVarName(sensorName);
+            wearable2MatlabNameLookup[sensorName] = channelName;
+            ok = ok && bufferManager.addChannel({channelName, {10, 1}});
+        }
+    }
+
+    ok  = ok && bufferManager.configure(bufferConfig);
+    if (ok) {
+        yDebug() << logPrefix << " buffer manager configured successfully.";
+    }
+
+    return ok;
+}
+
+void IWearLogger::threadRelease()
+{
+
+}
+
+bool IWearLogger::detach()
+{
+    std::lock_guard<std::mutex> guard(pImpl->loggerMutex);
+    while (isRunning()) {
+        stop();
+    }
+
+    pImpl->iWear = nullptr;
+    pImpl->iPreciselyTimed = nullptr;
+
+    return true;
+}
+
+// ==========================
+// IMultipleWrapper interface
+// ==========================
+
+bool IWearLogger::attachAll(const yarp::dev::PolyDriverList& driverList)
+{
+    if (driverList.size() > 1) {
+        yError() << logPrefix << "This wrapper accepts only one attached PolyDriver.";
+        return false;
+    }
+
+    const yarp::dev::PolyDriverDescriptor* driver = driverList[0];
+
+    if (!driver) {
+        yError() << logPrefix << "Passed PolyDriverDescriptor is nullptr.";
+        return false;
+    }
+
+    return attach(driver->poly);
+}
+
+bool IWearLogger::detachAll()
+{
+    return detach();
+}


### PR DESCRIPTION
This PR,
- adds an `AddInstallRPATHSupport` cmake module that was required to load the shared objects privately linked by the YARP device plugin.
- adds an `iwear_logger` wrapper device that can be attached to any wearable producer to log the data from all the sensors associated with the producer. 

At the heart of its implementation, It replaces,
> the `iwear_wrapper`'s logic of encapsulating the wearable sensors data into a WearableData msg and passing through a YARP port 

with 

> `yarp-telemetry`'s logic of dumping the data into a mat file.

A template for configuring the `iwear_logger` wrapper device can be as follows,

``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
<robot name="robot-name" build=0 portprefix="">
    <!--Producer Device -->
    <device type="producer_name" name="ProducerDevice">
        <!-- producer parameters go here -->
    </device>
    
    <device type="iwear_logger" name="ProducerLoggerDevice">
        <param name="period">0.01</param>
        
        <param name="logAllQuantities">false</param>
        <param name="logAccelerometers">false</param>
        <param name="logEMGSensors">false</param>
        <param name="logForce3DSensors">false</param>
        <param name="logForceTorque6DSensors">true</param>
        <param name="logFreeBodyAccelerationSensors">true</param>
        <param name="logGyroscopes">true</param>
        <param name="logMagnetometers">false</param>
        <param name="logOrientationSensors">true</param>
        <param name="logPoseSensors">false</param>
        <param name="logPositionSensors">false</param>
        <param name="logTemperatureSensors">false</param>
        <param name="logTorque3DSensors">false</param>
        <param name="logVirtualLinkKinSensors">false</param>
        <param name="logVirtualJointKinSensors">false</param>
        <param name="logVirtualSphericalJointKinSensors">false</param>                
        
        <param name="saveBufferManagerConfiguration">true</param>
        <param name="experimentName">test_iwear_logger</param>
        <param name="path">/path/to/some/folder/</param>
        <param name="n_samples">100000</param>
        <param name="save_periodically">true</param>
        <param name="save_period">120.0</param>
        <param name="data_threshold">300</param>
        <param name="auto_save">true</param>

        <action phase="startup" level="5" type="attach">
            <paramlist name="networks">
            	<!-- attach the source device here -->
                <elem name="ProducerDeviceWrapperLabel"> ProducerDevice </elem>
            </paramlist>
        </action>
        <action phase="shutdown" level="5" type="detach"/>
    </device>

</robot>
```


The data is saved as a  `<experimentName>_<timestamp>.mat` in the specified `<path>` parameter. 
This mat file contains a struct called `<experimentName>`

The sensors data are stored as a struct one for each wearable sensor. The name of this struct is a modified format of Wearable sensor name accounting for Matlab variable name handling. (Special characters like `@/()#` are converted to underscores and the wearable separator is converted to underscore.)
```
<producer-device-name>_<sensor-type>_<sensor-name>
   --- data
   --- dimensions
   --- name
   --- timestamps 

```


### TODO
- [x] Update CHANGELOG
- [x] Add example `xml` file to `app/xml`
- [x] Update CI for `yarp-telemetry`
- [ ] Update robology-superbuild's wearable dependency for `yarp-telemetry`

Closes #112 