### PR TITLE
Fix Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.1] - 2021-04-12
-
 ### Added
 - Added `iwear_logger` wrapper device to log wearable sensors data using `yarp-telemetry`. (https://github.com/robotology/wearables/pull/113)
 - Added `AddInstallRPATHSupport` cmake module for linking shared objects of private dependencies. (https://github.com/robotology/wearables/pull/113)
 - Updated `Paexo` wearable device with 6D force torque sensors implementation using `iFeelDriver`. (https://github.com/robotology/wearables/pull/117) 
+
+## [1.2.1] - 2021-04-12
 
 ### Fixed
   - Fixed linking-related bug in the CMake build system that ignored the `LDFLAGS`  environment variable, breaking the build on some environments (https://github.com/robotology/wearables/pull/110).


### PR DESCRIPTION
The updates on the `CHANGELOG` introduced in #113 and #117 have been done under `[1.2.1]` release section (see https://github.com/robotology/wearables/blob/master/CHANGELOG.md#121---2021-04-12), while they should go under [`unreleased`](https://github.com/robotology/wearables/blob/master/CHANGELOG.md#unreleased)

cc @Yeshasvitvs @prashanthr05 
