### PR TITLE
Add Xsens saveCurrentCalibration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `iwear_logger` wrapper device to log wearable sensors data using `yarp-telemetry`. (https://github.com/robotology/wearables/pull/113)
 - Added `AddInstallRPATHSupport` cmake module for linking shared objects of private dependencies. (https://github.com/robotology/wearables/pull/113)
-- Updated `Paexo` wearable device with 6D force torque sensors implementation using `iFeelDriver`. (https://github.com/robotology/wearables/pull/117) 
+- Updated `Paexo` wearable device with 6D force torque sensors implementation using `iFeelDriver`. (https://github.com/robotology/wearables/pull/117)
+- Updated `Xsens` wearable device with `saveCurrentCalibration` option. (https://github.com/robotology/wearables/pull/120)
 
 ## [1.2.1] - 2021-04-12
 

--- a/XSensMVN/include/XSensMVNDriver.h
+++ b/XSensMVN/include/XSensMVNDriver.h
@@ -144,6 +144,7 @@ namespace xsensmvn {
         const bodyDimensions bodyDimensions;
         const DriverDataStreamConfig dataStreamConfiguration;
         const bool saveMVNRecording;
+        const bool saveConfiguration;
     };
 
     enum class DriverStatus

--- a/XSensMVN/include/XSensMVNDriver.h
+++ b/XSensMVN/include/XSensMVNDriver.h
@@ -144,7 +144,7 @@ namespace xsensmvn {
         const bodyDimensions bodyDimensions;
         const DriverDataStreamConfig dataStreamConfiguration;
         const bool saveMVNRecording;
-        const bool saveConfiguration;
+        const bool saveCurrentCalibration;
     };
 
     enum class DriverStatus

--- a/XSensMVN/src/XSensMVNDriverImpl.cpp
+++ b/XSensMVN/src/XSensMVNDriverImpl.cpp
@@ -659,7 +659,8 @@ bool XSensMVNDriverImpl::calibrate(const std::string calibrationType)
         // Record the success of the calibration
         m_driverStatus = DriverStatus::CalibratedAndReadyToRecord;
 
-        if(m_driverConfiguration.saveMVNRecording)
+        // Save calibration and .mvn record
+        if(m_driverConfiguration.saveMVNRecording || m_driverConfiguration.saveConfiguration)
         {
             //Start recording .mvn file
             time_t rawtime;
@@ -676,13 +677,25 @@ bool XSensMVNDriverImpl::calibrate(const std::string calibrationType)
             std::replace(time_string.begin(), time_string.end(), ' ', '_'); //Replace space with underscore
             std::replace(time_string.begin(), time_string.end(), '-', '_'); //Replace - with underscore
             std::replace(time_string.begin(), time_string.end(), ':', '_'); //Replace : with underscore
-        
-            const XsString mvnFileName("recording_" + time_string);
 
-            xsInfo << "Recording to " << mvnFileName.toStdString() << ".mvn file";
+            if(m_driverConfiguration.saveMVNRecording)
+            {
+                const XsString mvnFileName("recording_" + time_string);
 
-            m_connection->createMvnFile(mvnFileName);
-            m_connection->startRecording();
+                xsInfo << "Recording to " << mvnFileName.toStdString() << ".mvn file";
+
+                m_connection->createMvnFile(mvnFileName);
+                m_connection->startRecording();
+            }
+
+            if (m_driverConfiguration.saveConfiguration)
+            {
+                const XsString mvnxFileName("recording_" + time_string + ".mvnx");
+
+                xsInfo << "Configuration saved to " << mvnxFileName.toStdString() << " file";
+
+                m_connection->saveCurrentCalibration(mvnxFileName);
+            }
         }
 
         m_calibrator->getLastCalibrationInfo(m_calibrationInfo.type, m_calibrationInfo.quality);

--- a/XSensMVN/src/XSensMVNDriverImpl.cpp
+++ b/XSensMVN/src/XSensMVNDriverImpl.cpp
@@ -660,7 +660,7 @@ bool XSensMVNDriverImpl::calibrate(const std::string calibrationType)
         m_driverStatus = DriverStatus::CalibratedAndReadyToRecord;
 
         // Save calibration and .mvn record
-        if(m_driverConfiguration.saveMVNRecording || m_driverConfiguration.saveConfiguration)
+        if(m_driverConfiguration.saveMVNRecording || m_driverConfiguration.saveCurrentCalibration)
         {
             //Start recording .mvn file
             time_t rawtime;
@@ -688,13 +688,13 @@ bool XSensMVNDriverImpl::calibrate(const std::string calibrationType)
                 m_connection->startRecording();
             }
 
-            if (m_driverConfiguration.saveConfiguration)
+            if (m_driverConfiguration.saveCurrentCalibration)
             {
-                const XsString mvnxFileName("recording_" + time_string + ".mvnx");
+                const XsString mvnFileName("recording_" + time_string + "_calibration.mvn");
 
-                xsInfo << "Configuration saved to " << mvnxFileName.toStdString() << " file";
+                xsInfo << "Calibration saved to " << mvnFileName.toStdString() << " file";
 
-                m_connection->saveCurrentCalibration(mvnxFileName);
+                m_connection->saveCurrentCalibration(mvnFileName);
             }
         }
 

--- a/app/xml/XsensSuitWearableDevice.xml
+++ b/app/xml/XsensSuitWearableDevice.xml
@@ -27,9 +27,9 @@
         <param name="sampling-rate">120</param>
         <!-- Flag to save mvn recording -->
         <param name="saveMVNRecording">false</param>
-		<!-- Flag to save .mvn calibration -->
-		<param name="saveCurrentCalibration">true</param>
-		<!-- Quantities to be extracted from the driver for each time sample -->
+		    <!-- Flag to save .mvn calibration -->
+		    <param name="saveCurrentCalibration">true</param>
+		    <!-- Quantities to be extracted from the driver for each time sample -->
         <group name="output-stream-configuration">
             <param name="enable-joint-data">true</param>
             <param name="enable-link-data">true</param>
@@ -48,7 +48,7 @@
             <param name="shoeSoleHeight">0.02</param>
         </group>
     </device>
-    
+
     <device type="iwear_wrapper" name="XSensSuitDeviceWrapper">
         <param name="period">0.01</param>
         <param name="dataPortName">/XSensSuit/WearableData/data:o</param>
@@ -60,7 +60,7 @@
         </action>
         <action phase="shutdown" level="5" type="detach"/>
     </device>
-    
+
     <device type="ixsensmvncontrol_wrapper" name="XSensSuitControl">
         <param name="rpcPortName">/XSensSuit/Control/rpc:i</param>
         <action phase="startup" level="5" type="attach">
@@ -70,4 +70,4 @@
         </action>
         <action phase="shutdown" level="5" type="detach"/>
     </device>
-</robot> 
+</robot>

--- a/app/xml/XsensSuitWearableDevice.xml
+++ b/app/xml/XsensSuitWearableDevice.xml
@@ -27,8 +27,8 @@
         <param name="sampling-rate">120</param>
         <!-- Flag to save mvn recording -->
         <param name="saveMVNRecording">false</param>
-		<!-- Flag to save .mvnx calibration -->
-		<param name="saveConfiguration">true</param>
+		<!-- Flag to save .mvn calibration -->
+		<param name="saveCurrentCalibration">true</param>
 		<!-- Quantities to be extracted from the driver for each time sample -->
         <group name="output-stream-configuration">
             <param name="enable-joint-data">true</param>

--- a/app/xml/XsensSuitWearableDevice.xml
+++ b/app/xml/XsensSuitWearableDevice.xml
@@ -18,8 +18,8 @@
         <!-- NposeWalk - TposeWalk - Npose - Tpose-->
         <param name="default-calibration-type">Npose</param>
         <!-- Minimum calibration quality to be considered good enought to be applied and allow the acquisition to start. Available values are: -->
-        <!-- Poor - Acceptable -- Good -->
-        <param name="minimum-calibration-quality-required">Acceptable</param>
+        <!-- Poor - Acceptable - Good -->
+        <param name="minimum-calibration-quality-required">Poor</param>
         <!-- Maximum Time [s] to scan for the suit. Set to -1 enables endless scan-->
         <param name="scan-timeout">60</param>
         <!-- Sampling rate [Hz]. Available values are:-->
@@ -27,7 +27,9 @@
         <param name="sampling-rate">120</param>
         <!-- Flag to save mvn recording -->
         <param name="saveMVNRecording">false</param>
-        <!-- Quantities to be extracted from the driver for each time sample -->
+		<!-- Flag to save .mvnx calibration -->
+		<param name="saveConfiguration">true</param>
+		<!-- Quantities to be extracted from the driver for each time sample -->
         <group name="output-stream-configuration">
             <param name="enable-joint-data">true</param>
             <param name="enable-link-data">true</param>

--- a/app/xml/XsensSuitWearableDevice.xml
+++ b/app/xml/XsensSuitWearableDevice.xml
@@ -27,9 +27,9 @@
         <param name="sampling-rate">120</param>
         <!-- Flag to save mvn recording -->
         <param name="saveMVNRecording">false</param>
-		    <!-- Flag to save .mvn calibration -->
-		    <param name="saveCurrentCalibration">true</param>
-		    <!-- Quantities to be extracted from the driver for each time sample -->
+	<!-- Flag to save .mvn calibration -->
+        <param name="saveCurrentCalibration">true</param>
+        <!-- Quantities to be extracted from the driver for each time sample -->
         <group name="output-stream-configuration">
             <param name="enable-joint-data">true</param>
             <param name="enable-link-data">true</param>

--- a/devices/XsensSuit/src/XsensSuit.cpp
+++ b/devices/XsensSuit/src/XsensSuit.cpp
@@ -765,12 +765,23 @@ bool XsensSuit::open(yarp::os::Searchable& config)
     // Check for mvn recording flag
     bool saveMVNRecording;
     if (!config.check("saveMVNRecording")) {
-        yWarning() << logPrefix << "OPTIONAL parameter <saveMVNRecording> NOT found, setting it to False.";
+        yWarning() << logPrefix << "OPTIONAL parameter <saveMVNRecording> NOT found, setting it to false.";
         saveMVNRecording = false;
     }
     else {
+        saveMVNRecording = config.find("saveMVNRecording").asBool();
         yInfo() << logPrefix << "<saveMVNRecording> parameter set to " << saveMVNRecording;
-        saveMVNRecording = config.find("saveMVNRecording").asBool();        
+    }
+
+    // Check for saving configuration flag
+    bool saveConfiguration;
+    if (!config.check("saveConfiguration")) {
+        yWarning() << logPrefix << "OPTIONAL parameter <saveConfiguration> NOT found, setting it to false.";
+        saveConfiguration = false;
+    }
+    else {
+        saveConfiguration = config.find("saveConfiguration").asBool();
+        yInfo() << logPrefix << "<saveConfiguration> parameter set to " << saveConfiguration;
     }
 
     xsensmvn::DriverConfiguration driverConfig{rundepsFolder,
@@ -782,7 +793,8 @@ bool XsensSuit::open(yarp::os::Searchable& config)
                                                samplingRate,
                                                subjectBodyDimensions,
                                                outputStreamConfig,
-                                               saveMVNRecording};
+                                               saveMVNRecording,
+                                               saveConfiguration};
 
     pImpl->driver.reset(new xsensmvn::XSensMVNDriver(driverConfig));
 

--- a/devices/XsensSuit/src/XsensSuit.cpp
+++ b/devices/XsensSuit/src/XsensSuit.cpp
@@ -773,15 +773,15 @@ bool XsensSuit::open(yarp::os::Searchable& config)
         yInfo() << logPrefix << "<saveMVNRecording> parameter set to " << saveMVNRecording;
     }
 
-    // Check for saving configuration flag
-    bool saveConfiguration;
-    if (!config.check("saveConfiguration")) {
-        yWarning() << logPrefix << "OPTIONAL parameter <saveConfiguration> NOT found, setting it to false.";
-        saveConfiguration = false;
+    // Check for saving current calibration flag
+    bool saveCurrentCalibration;
+    if (!config.check("saveCurrentCalibration")) {
+        yWarning() << logPrefix << "OPTIONAL parameter <saveCurrentCalibration> NOT found, setting it to false.";
+        saveCurrentCalibration = false;
     }
     else {
-        saveConfiguration = config.find("saveConfiguration").asBool();
-        yInfo() << logPrefix << "<saveConfiguration> parameter set to " << saveConfiguration;
+        saveCurrentCalibration = config.find("saveCurrentCalibration").asBool();
+        yInfo() << logPrefix << "<saveCurrentCalibration> parameter set to " << saveCurrentCalibration;
     }
 
     xsensmvn::DriverConfiguration driverConfig{rundepsFolder,
@@ -794,7 +794,7 @@ bool XsensSuit::open(yarp::os::Searchable& config)
                                                subjectBodyDimensions,
                                                outputStreamConfig,
                                                saveMVNRecording,
-                                               saveConfiguration};
+                                               saveCurrentCalibration};
 
     pImpl->driver.reset(new xsensmvn::XSensMVNDriver(driverConfig));
 


### PR DESCRIPTION
This PR adds the option of `saveCurrentCalibration` to Xsens wearable device

![Screenshot 2021-06-04 153950](https://user-images.githubusercontent.com/6505998/120810662-889ad680-c54b-11eb-82fe-e80a4a5cb693.png)

![Screenshot 2021-06-04 154031](https://user-images.githubusercontent.com/6505998/120810667-89336d00-c54b-11eb-9cae-0af24b779e33.png)


The saved calibration file is with `.mvn` file extension

CC @lrapetti @claudia-lat @DanielePucci 