### PR TITLE
Fix installation of Wearable/IWear/Utils.h install

### DIFF
--- a/interfaces/IWear/CMakeLists.txt
+++ b/interfaces/IWear/CMakeLists.txt
@@ -50,6 +50,9 @@ install(
     FILES include/Wearable/IWear/IWear.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Wearable/IWear)
 install(
+    FILES include/Wearable/IWear/Utils.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Wearable/IWear)
+install(
     DIRECTORY include/Wearable/IWear/Sensors
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Wearable/IWear)
 install(


### PR DESCRIPTION
PR https://github.com/robotology/wearables/pull/126 move the `Wearable/IWear/Sensors/Utils.h` include to `Wearable/IWear/Utils.h`. However, this change was not accounted for in the installation rules,  neither documented in the CHANGELOG. This PR fixes the first issue to fix https://github.com/robotology/robotology-superbuild/issues/846 .