### PR TITLE
Add ISkinSensor management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Added management of `ISkinSensor`. (https://github.com/robotology/wearables/pull/139)
 ## [1.2.2] - 2021-10-28
 
 ### Removed

--- a/app/xml/iWearLoggerExampleTemplate.xml
+++ b/app/xml/iWearLoggerExampleTemplate.xml
@@ -29,6 +29,7 @@
         <param name="logVirtualLinkKinSensors">false</param>
         <param name="logVirtualJointKinSensors">false</param>
         <param name="logVirtualSphericalJointKinSensors">false</param>                
+        <param name="logSkinSensors">false</param>
         
         <param name="saveBufferManagerConfiguration">true</param>
         <param name="experimentName">test_iwear_logger</param>

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -452,13 +452,11 @@ void IWearRemapper::onRead(msg::WearableData& receivedWearData)
         }
         const auto* constSensor = static_cast<const sensor::impl::SkinSensor*>(isensor.get());
         auto* sensor = const_cast<sensor::impl::SkinSensor*>(constSensor);
-        yWarning() << logPrefix << "SkinSensor is not yet implemented";
-        // Copy its data to the buffer used for exposing the IWear interface
-        //        pImpl->skinSensors[inputSensorName]->setBuffer(
-        //            {wearDataInputSensor.data.x, wearDataInputSensor.data.y,
-        //            wearDataInputSensor.data.z});
-        //        // Set the status
-        //        sensor->setStatus(MapSensorStatus.at(wearDataInputSensor.info.status));
+
+        //Copy its data to the buffer used for exposing the IWear interface
+        sensor->setBuffer(wearDataInputSensor.data);
+        // Set the status
+        sensor->setStatus(MapSensorStatus.at(wearDataInputSensor.info.status));
     }
 
     for (auto& s : receivedWearData.temperatureSensors) {

--- a/msgs/thrift/WearableData.thrift
+++ b/msgs/thrift/WearableData.thrift
@@ -138,7 +138,7 @@ struct PositionSensor {
 
 struct SkinSensor {
   1: SensorInfo info;
-  2: VectorXYZ data;
+  2: list<double> data;
 }
 
 struct TemperatureSensor {

--- a/wrappers/IWear/src/IWearWrapper.cpp
+++ b/wrappers/IWear/src/IWearWrapper.cpp
@@ -315,8 +315,17 @@ void IWearWrapper::run()
         }
     }
     {
-        if (pImpl->skinSensors.size() > 0) {
-            yWarning() << logPrefix << "SkinSensor not yet implemented.";
+        for (const auto& sensor : pImpl->skinSensors) {
+            std::vector<double> pressureVector;
+            if (!sensor->getPressure(pressureVector)) {
+                yWarning() << logPrefix << "[SkinSensors] "
+                         << "Failed to read data, "
+                         << "sensor status is "
+                         << static_cast<int>(sensor->getSensorStatus());
+            }
+
+            data.skinSensors[sensor->getSensorName()] = {generateSensorStatus(sensor.get()),
+                                                         pressureVector};
         }
     }
     {


### PR DESCRIPTION
Opening this PR to add the management of ISkinSensors.

The definition of the message has been updated to hold a vector of double representing the pressure data exerted on the skin taxels.

`IWearWrapper`, `IWearRemapper` and `IWearLogger` have been updated accordingly.

The implementation has been tested in the context of https://github.com/ami-iit/element_stretchable-insole/issues/134.