### PR TITLE
Disable default enabling of XsensSuit device 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,6 @@ jobs:
             cd build
             cmake -G"Visual Studio 16 2019" -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                                             -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
-                                            -DXSENS_MVN_USE_SDK:BOOL=OFF \
                                             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 
         - name: Configure [Ubuntu/macOS]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed forceStrict to false when writing on ports. (https://github.com/robotology/wearables/pull/137)
+- Disabled build of XsensSuit device by default. (https://github.com/robotology/wearables/pull/141)
 
 ## [1.2.2] - 2021-10-28
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,17 +57,17 @@ if(UNIX AND NOT APPLE)
 endif()
 
 if(WIN32)
-  option(XSENS_MVN_USE_SDK "Build the driver and the wrapper for the real MVN system using the MVN SDK" ON)
   #Add compile definition to suppress warning related to header <experimental/filesystem>
   add_compile_definitions(_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING)
-  if(XSENS_MVN_USE_SDK)
-    find_package(XsensXME REQUIRED)
+
+  # Flag to enable XSensSuit wearable device
+  option(ENABLE_XsensSuit "Flag that enables building XsensSuit wearable device" OFF)
+  if(ENABLE_XsensSuit)
+    find_package(XsensXME)
     if(NOT ${XsensXME_FOUND})
-      message("XSENS XME not found but option to use it is enabled.")
-      return()
-    else()
-      add_subdirectory(XSensMVN)
-      endif()
+      message(FATAL_ERROR "XsensSuit device requires XSENS XME!")
+    endif()
+    add_subdirectory(XSensMVN)
   endif()
 endif()
 

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -12,7 +12,7 @@ if(ENABLE_Paexo)
     add_subdirectory(Paexo)
 endif()
 
-if(XSENS_MVN_USE_SDK)
+if(ENABLE_XsensSuit)
   add_subdirectory(XsensSuit)
 endif()
 


### PR DESCRIPTION
This PR to disable the building of the XsensSuit device by default on Windows, since one may want to use the wearable library without it.

I also changed the name of the `XSENS_MVN_USE_SDK` option to  `Enable_XsensSuit` to be in line with the other devices.

One thing that can be done is enabling the option by default only if `XsensXME` is found.