### PR TITLE
Add dependencies for IWearLogger in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Here following there is a list of the required dependencies you need for using t
 
 It must be noted that `YARP`, together with a subset of the optional dependencies, can be installed together in one place using the [robotology-superbuild](https://github.com/robotology/robotology-superbuild) enabling its [`Human-Dynamics` profile](https://github.com/robotology/robotology-superbuild#human-dynamics).
 
+### Optional
+* [YARP-telemetry](https://github.com/robotology/yarp-telemetry) device: if present, the `IWearLogger` is installed.
+
 ## Build the suite
 ### Linux/macOS
 

--- a/wrappers/IWearLogger/CMakeLists.txt
+++ b/wrappers/IWearLogger/CMakeLists.txt
@@ -30,5 +30,7 @@ yarp_install(
     ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
     YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
 
+else()
+    message(WARNING "YARP-telemetry is missing. IWearLogger will not be installed.")
 endif()
 


### PR DESCRIPTION
This PR to enhance the documentation related to `IWearLogger`.

As for now, it is not built/installed if `yarp-telemetry` is missing. In order to make users aware of that, I added the info on the README's dependencies section. I also added a CMake warning message for the same purpose.