### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           run: |
             mkdir -p build
             cd build
-            cmake -G"Visual Studio 16 2019" -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
+            cmake -G"Visual Studio 17 2022" -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
                                             -DCMAKE_BUILD_TPYE=${{matrix.build_type}} \
                                             -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
 


### PR DESCRIPTION
The last CI action https://github.com/robotology/wearables/actions/runs/1896455781 fails the build on `windows-latest`.
This is due to the fact that `windows-latest` is now `windows-2022` (see https://github.com/actions/virtual-environments/issues/4856).

This PR to update the CMake generator to `Visual Studio 17 2022`.