### PR TITLE
Restore robometry in the windows ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
             # Compilation related dependencies
             mamba install cmake compilers make ninja pkg-config
             # Actual dependencies
-            mamba install -c robotology yarp idyntree matio-cpp
+            mamba install -c robotology yarp idyntree matio-cpp robometry
 
         # ===================
         # CMAKE-BASED PROJECT


### PR DESCRIPTION
It is possible because now the conda packages of robometry are available: https://anaconda.org/robotology/robometry.

It fixes #156