### PR TITLE
Improve cmake installation flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `IWearLogger` compilation is enabled by the cmake flag `ENABLE_Logger`, that is set to `ON` by default if `robometry` is found. (https://github.com/robotology/wearables/pull/159)
+- `ICub` wearable device compilation is enabled by the cmake flag `ENABLE_ICub`, that is set to `ON` by default if `iDynTree` is found. (https://github.com/robotology/wearables/pull/159)
+- `ENABLE_FrameVisualizer` cmake falg is set to `ON` by default if `iDynTree` is found. (https://github.com/robotology/wearables/pull/159)
+- `ENABLE_XsensSuit` cmake falg is set to `ON` by default if `XsensXME` is found. (https://github.com/robotology/wearables/pull/159)
+
 ## [1.4.0] - 2022-05-24
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,4 +94,12 @@ option(ENABLE_Paexo "Flag that enables building Paexo wearable device" OFF)
 option(ENABLE_HapticGlove "Flag that enables building Haptic Sense Glove wearable device" OFF)
 
 # Flag to enable IWearFrameVisualizer module
-option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" OFF)
+find_package(iDynTree QUIET)
+option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" ${iDynTree_FOUND})
+
+# Flag to enable IWearLogger device
+find_package(robometry QUIET)
+option(ENABLE_Logger "Flag that enables building Wearable Logger device" ${robometry_FOUND})
+
+# Flag to enable ICub wearable device
+option(ENABLE_ICub "Flag that enables building iCub wearable device" ${iDynTree_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,16 +59,6 @@ endif()
 if(WIN32)
   #Add compile definition to suppress warning related to header <experimental/filesystem>
   add_compile_definitions(_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING)
-
-  # Flag to enable XSensSuit wearable device
-  option(ENABLE_XsensSuit "Flag that enables building XsensSuit wearable device" OFF)
-  if(ENABLE_XsensSuit)
-    find_package(XsensXME)
-    if(NOT ${XsensXME_FOUND})
-      message(FATAL_ERROR "XsensSuit device requires XSENS XME!")
-    endif()
-    add_subdirectory(XSensMVN)
-  endif()
 endif()
 
 add_subdirectory(interfaces)
@@ -86,6 +76,13 @@ add_subdirectory(devices)
 add_subdirectory(wrappers)
 add_subdirectory(app)
 add_subdirectory(modules)
+
+# Flag to enable XSensSuit wearable device
+find_package(XsensXME QUIET)
+option(ENABLE_XsensSuit "Flag that enables building XsensSuit wearable device" ${XsensXME_FOUND})
+if(ENABLE_XsensSuit)
+  add_subdirectory(XSensMVN)
+endif()
 
 # Flag to enable Paexo wearable device
 option(ENABLE_Paexo "Flag that enables building Paexo wearable device" OFF)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note that this is not necessary if you install `wearables` via the `robotology-s
 The compilation of some of the software components in `wearables` can be enabled using the following cmake flags:
 - `ENABLE_FrameVisualizer`: enable the compilation of the `IWearFrameVisualizer` modeule that allows to visualize wearble inertial measurements.
 - `ENABLE_Logger`: enable the compilation of the `IWearLogger` device that allows to save wearable data as `.mat` or stream the data on YARP as analog vector data.
-- `ENABLE_<device>`: enable teh compilation of the optional wearable device (see documentation in [Wearable device sources](#wearable-device-sources)).
+- `ENABLE_<device>`: enable the compilation of the optional wearable device (see documentation in [Wearable device sources](#wearable-device-sources)).
 
 
 # Wearable device sources

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Here following there is a list of the required dependencies you need for using t
 It must be noted that `YARP`, together with a subset of the optional dependencies, can be installed together in one place using the [robotology-superbuild](https://github.com/robotology/robotology-superbuild) enabling its [`Human-Dynamics` profile](https://github.com/robotology/robotology-superbuild#human-dynamics).
 
 ### Optional
-* [robometry](https://github.com/robotology/robometry) device: if present, the `IWearLogger` is installed.
-* [iDynTree](https://github.com/robotology/idyntree): if present, the `IWearFrameVisualizer` is installed.
+* [robometry](https://github.com/robotology/robometry) device: if present, the `IWearLogger` device is installed by default.
+* [iDynTree](https://github.com/robotology/idyntree): if present, the `IWearFrameVisualizer` module and `ICub` device are installed by default.
 
 ## Build the suite
 ### Linux/macOS
@@ -34,6 +34,12 @@ export YARP_DATA_DIRS=${YARP_DATA_DIRS}:${WEARABLES_INSTALL_DIR}/share/yarp
 ```
 Note that this is not necessary if you install `wearables` via the `robotology-superbuild`.
 
+### Optional flags
+The compilation of some of the software components in `wearables` can be enabled using the following cmake flags:
+- `ENABLE_FrameVisualizer`: enable the compilation of the `IWearFrameVisualizer` modeule that allows to visualize wearble inertial measurements.
+- `ENABLE_Logger`: enable the compilation of the `IWearLogger` device that allows to save wearable data as `.mat` or stream the data on YARP as analog vector data.
+- `ENABLE_<device>`: enable teh compilation of the optional wearable device (see documentation in [Wearable device sources](#wearable-device-sources)).
+
 
 # Wearable device sources
 Wearable devices contained in [`/devices/`](/devices) are [YARP devices](http://www.yarp.it/git-master/note_devices.html) that exposes sensors data using `IWear` interface. List of the dependencies and documentation for running some of the wearable data sources can be found at the links in the table below. The compilation of some of theese devices can be enable/disabled changing the CMAKE option `ENABLE_<device>`.
@@ -41,9 +47,9 @@ Wearable devices contained in [`/devices/`](/devices) are [YARP devices](http://
 | Device Name | Description | OS | Dependencies| Documentation |
 |---------------|------|---------------|----------------------------------------------------------|------|
 | IAnalogSensor | Exposes YARP [`IAnalogSensor` Interface](http://www.yarp.it/git-master/classyarp_1_1dev_1_1IAnalogSensor.html). |  Linux/MacOS/Windows  | - |  - |
-| FTShoes | Exposes YARP [`ftShoe`](https://github.com/robotology/forcetorque-yarp-devices/tree/master/ftShoe) data. |  Linux/MacOS/Windows   | [forcetorque-yarp-devices](https://github.com/robotology/forcetorque-yarp-devices) | [:books:](/doc/How-to-run-FTshoes.md) |
-| XsensSuit | Exposes [XsensSuit](https://www.xsens.com/motion-capture) data. |  Windows   | xsens MVN SDK 2018.0.3 | [:books:](/doc/How-to-run-XsensSuit.md) |
-| iCub | Exposes [iCub](https://icub.iit.it/) robot data. |  Linux/MacOS/Windows   | [idyntree](https://github.com/robotology/idyntree) | [:books:](/doc/How-to-run-iCub-as-wearable-source.md) |
-| Paexo | Exposes [Paexo](https://paexo.com/?lang=en) data. |  Linux  | Optional flag `ENABLE_PAEXO_USE_iFEELDriver` to use `iFeelDriver` (Contact the maintainer for more details) | - |
-| HapticGlove | Exposes [SenseGlove](https://www.senseglove.com/product/developers-kit/) data. |  Linux/Windows  | [SenseGloveSDK](https://github.com/Adjuvo/SenseGlove-API) | [:books:](./doc/How-to-compile-and-run-HapticGlove.md) |
+| FTShoes | Exposes YARP [`ftShoe`](https://github.com/robotology/forcetorque-yarp-devices/tree/master/ftShoe) data. |  Linux/MacOS/Windows   | [`forcetorque-yarp-devices`](https://github.com/robotology/forcetorque-yarp-devices) | [:books:](/doc/How-to-run-FTshoes.md) |
+| XsensSuit | Exposes [`XsensSuit`](https://www.xsens.com/motion-capture) data. |  Windows   | xsens MVN SDK 2018.0.3 | [:books:](/doc/How-to-run-XsensSuit.md) |
+| ICub | Exposes [iCub](https://icub.iit.it/) robot data. |  Linux/MacOS/Windows   | [`iDynTree`](https://github.com/robotology/idyntree) | [:books:](/doc/How-to-run-iCub-as-wearable-source.md) |
+| Paexo | Exposes [Paexo](https://paexo.com/?lang=en) data. |  Linux  | `iFeelDriver` (Contact the maintainer for more details) | - |
+| HapticGlove | Exposes [SenseGlove](https://www.senseglove.com/product/developers-kit/) data. |  Linux/Windows  | [`SenseGloveSDK`](https://github.com/Adjuvo/SenseGlove-API) | [:books:](./doc/How-to-compile-and-run-HapticGlove.md) |
 | IFrameTransform | Exposes YARP [`IFrameTransform` Interface](http://www.yarp.it/git-master/classyarp_1_1dev_1_1IFrameTransform.html). |  Linux/MacOS/Windows  | - |  - |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note that this is not necessary if you install `wearables` via the `robotology-s
 
 ### Optional flags
 The compilation of some of the software components in `wearables` can be enabled using the following cmake flags:
-- `ENABLE_FrameVisualizer`: enable the compilation of the `IWearFrameVisualizer` modeule that allows to visualize wearble inertial measurements.
+- `ENABLE_FrameVisualizer`: enable the compilation of the `IWearFrameVisualizer` module that allows to visualize wearble inertial measurements.
 - `ENABLE_Logger`: enable the compilation of the `IWearLogger` device that allows to save wearable data as `.mat` or stream the data on YARP as analog vector data.
 - `ENABLE_<device>`: enable the compilation of the optional wearable device (see documentation in [Wearable device sources](#wearable-device-sources)).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It must be noted that `YARP`, together with a subset of the optional dependencie
 
 ### Optional
 * [robometry](https://github.com/robotology/robometry) device: if present, the `IWearLogger` is installed.
+* [iDynTree](https://github.com/robotology/idyntree): if present, the `IWearFrameVisualizer` is installed.
 
 ## Build the suite
 ### Linux/macOS

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -16,7 +16,7 @@ if(ENABLE_XsensSuit)
   add_subdirectory(XsensSuit)
 endif()
 
-if(iDynTree_FOUND)
+if(ENABLE_ICub)
   add_subdirectory(ICub)
 endif()
 

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -5,5 +5,9 @@
 add_subdirectory(IWear)
 add_subdirectory(IWearActuators)
 add_subdirectory(IXsensMVNControl)
-add_subdirectory(IWearLogger)
+
+if(ENABLE_Logger)
+    add_subdirectory(IWearLogger)
+endif()
+
 

--- a/wrappers/IWearLogger/CMakeLists.txt
+++ b/wrappers/IWearLogger/CMakeLists.txt
@@ -2,9 +2,8 @@
 # This software may be modified and distributed under the terms of the
 # GNU Lesser General Public License v2.1 or any later version.
 
-find_package(YARP COMPONENTS dev QUIET)
-find_package(robometry QUIET)
-if (${YARP_FOUND} AND ${robometry_FOUND})
+find_package(YARP COMPONENTS dev REQUIRED)
+find_package(robometry REQUIRED)
 
 yarp_prepare_plugin(iwear_logger
     TYPE wearable::wrappers::IWearLogger
@@ -29,8 +28,3 @@ yarp_install(
     LIBRARY DESTINATION ${YARP_DYNAMIC_PLUGINS_INSTALL_DIR}
     ARCHIVE DESTINATION ${YARP_STATIC_PLUGINS_INSTALL_DIR}
     YARP_INI DESTINATION ${YARP_PLUGIN_MANIFESTS_INSTALL_DIR})
-
-else()
-    message(WARNING "robometry is missing. IWearLogger will not be installed.")
-endif()
-


### PR DESCRIPTION
This PR improves the usage of cmake flags for the installation of optional software components in wearables, trying to unify the behaviour.

In particular:
- avoids hidden `if` selecting software components
- change default flags values depending on the found dependencies


The documentation is also updated and improved accordingly