### PR TITLE
Install WearableData interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- The minimum required version of CMake is now 3.16 (https://github.com/robotology/wearables/pull/165).
 
-The minimum required version of CMake is now 3.16 (https://github.com/robotology/wearables/pull/165).
+### Added
+- Add installation of WearableData thrift messages. (https://github.com/robotology/wearables/pull/166).
 
 ## [1.5.0] - 2022-09-13
 

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -40,9 +40,19 @@ target_include_directories(WearableData PUBLIC
     $<BUILD_INTERFACE:${WEARABLEDATA_INCLUDE_DIRS}>)
 
 install(TARGETS WearableData
+        EXPORT WearableData
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install_basic_package_files(WearableData
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion
+        EXPORT WearableData
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+install(FILES ${WEARABLEDATA_FILES}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/thrift)
 
 # =================
 # WearableActuators


### PR DESCRIPTION
WearableData messages interface is not currently installed. This PR to install them as done for the WearableActuators.

However, this is *not* the correct way to install the files, since they are under `${CMAKE_INSTALL_PREFIX}/thrifts`.

I will open an issue for that.