### PR TITLE
Fix #164

### DIFF
--- a/modules/IWearFrameVisualizer/CMakeLists.txt
+++ b/modules/IWearFrameVisualizer/CMakeLists.txt
@@ -19,7 +19,6 @@ endmacro()
 set(EXE_TARGET_NAME IWearFrameVisualizerModule)
 
 
-find_package(IWear REQUIRED)
 find_package(YARP REQUIRED)
 find_package(iDynTree REQUIRED)
 


### PR DESCRIPTION
As suggested by @traversaro in https://github.com/robotology/wearables/issues/164#issuecomment-1247799135 `find_package(IWear)` should not be called in the `IWearFrameVisualizer`