### PR TITLE
Allow IWearRemapper to attach and remap IWear interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The `IWearRemapper` can be attached also to IWear interfaces (https://github.com/robotology/wearables/pull/170)
+
 ### Removed
 - Remove unused definition in actuators thrift messages(https://github.com/robotology/wearables/pull/171).
 

--- a/devices/IWearRemapper/include/IWearRemapper.h
+++ b/devices/IWearRemapper/include/IWearRemapper.h
@@ -14,6 +14,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
+#include <yarp/dev/Wrapper.h>
 #include <yarp/os/TypedReaderCallback.h>
 
 #include <memory>
@@ -32,6 +33,7 @@ class wearable::devices::IWearRemapper
     , public wearable::IWear
     , public yarp::os::TypedReaderCallback<msg::WearableData>
     , public yarp::os::PeriodicThread
+    , public yarp::dev::IMultipleWrapper
     , public yarp::dev::IPreciselyTimed
 {
 private:
@@ -127,6 +129,10 @@ public:
 
     inline ElementPtr<const actuator::IHeater>
     getHeaterActuator(const actuator::ActuatorName) const override;
+
+    // IMultipleWrapper interface
+    bool attachAll(const yarp::dev::PolyDriverList& driverList) override;
+    bool detachAll() override;
 };
 
 inline wearable::ElementPtr<const wearable::actuator::IActuator>

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -39,6 +39,7 @@ public:
     TimeStamp timestamp;
     bool firstRun = true;
     bool terminationCall = false;
+    bool inputDataPorts = false;
 
     mutable std::recursive_mutex mutex;
 
@@ -89,82 +90,105 @@ IWearRemapper::~IWearRemapper() = default;
 
 bool IWearRemapper::open(yarp::os::Searchable& config)
 {
-    // ===============================
-    // CHECK THE CONFIGURATION OPTIONS
-    // ===============================
+    // =====================
+    // CHECK THE INPUT PORTS 
+    // =====================
 
-    // Data ports
-    if (!(config.check("wearableDataPorts") && config.find("wearableDataPorts").isList())) {
-        yError() << logPrefix << "wearableDataPorts option does not exist or it is not a list";
-        return false;
+
+    // Check if the wearableDataPorts is present
+    bool inputDataPortsConfigurationOption = config.check("wearableDataPorts");
+    yarp::os::Bottle* inputDataPortsNamesList;
+
+    if (!inputDataPortsConfigurationOption) {
+        // there are no input ports
+        pImpl->inputDataPorts = inputDataPortsConfigurationOption;
     }
-    yarp::os::Bottle* inputDataPortsNamesList = config.find("wearableDataPorts").asList();
-    for (unsigned i = 0; i < inputDataPortsNamesList->size(); ++i) {
-        if (!inputDataPortsNamesList->get(i).isString()) {
-            yError() << logPrefix << "ith entry of wearableDataPorts list is not a string";
+    else
+    {
+        // Check that wearableDataPorts option is a list
+        if (!config.find("wearableDataPorts").isList()) {
+            yError() << logPrefix << "wearableDataPorts option is not a list";
             return false;
+        }
+
+        inputDataPortsNamesList = config.find("wearableDataPorts").asList();
+        // If the list is not empty, parse the input ports
+        if (inputDataPortsNamesList->size() != 0) {
+            pImpl->inputDataPorts = true; 
+        }
+
+    }
+
+    if (pImpl->inputDataPorts) {
+
+        for (unsigned i = 0; i < inputDataPortsNamesList->size(); ++i) {
+            if (!inputDataPortsNamesList->get(i).isString()) {
+                yError() << logPrefix << "ith entry of wearableDataPorts list is not a string";
+                return false;
+            }
+        }
+
+        // ===============================
+        // PARSE THE CONFIGURATION OPTIONS
+        // ===============================
+
+        // Convert list to vector
+        std::vector<std::string> inputDataPortsNamesVector;
+        for (unsigned i = 0; i < inputDataPortsNamesList->size(); ++i) {
+            inputDataPortsNamesVector.emplace_back(inputDataPortsNamesList->get(i).asString());
+        }
+
+        yInfo() << logPrefix << "*** ========================";
+        for (unsigned i = 0; i < inputDataPortsNamesVector.size(); ++i) {
+            yInfo() << logPrefix << "*** Wearable Data Port" << i + 1 << "  :"
+                    << inputDataPortsNamesVector[i];
+        }
+
+        yInfo() << logPrefix << "*** ========================";
+
+        // Carrier optional configuration
+        std::string carrier = "";
+        if (config.check("carrier")) {
+            carrier = config.find("carrier").asString();
+        }
+
+        // ==========================
+        // CONFIGURE INPUT DATA PORTS
+        // ==========================
+        yDebug() << logPrefix << "Configuring input data ports";
+
+        for (unsigned i = 0; i < config.find("wearableDataPorts").asList()->size(); ++i) {
+            pImpl->inputPortsWearData.emplace_back(new yarp::os::BufferedPort<msg::WearableData>());
+            pImpl->inputPortsWearData.back()->useCallback(*this);
+
+            if (!pImpl->inputPortsWearData.back()->open("...")) {
+                yError() << logPrefix << "Failed to open local input port";
+                return false;
+            }
+        }
+
+        // ================
+        // OPEN INPUT PORTS
+        // ================
+        yDebug() << logPrefix << "Opening input ports";
+
+        for (unsigned i = 0; i < config.find("wearableDataPorts").asList()->size(); ++i) {
+            if (!yarp::os::Network::connect(inputDataPortsNamesVector[i],
+                                            pImpl->inputPortsWearData[i]->getName(),
+                                            carrier)) {
+                yError() << logPrefix << "Failed to connect " << inputDataPortsNamesVector[i]
+                        << " with " << pImpl->inputPortsWearData[i]->getName();
+                return false;
+            }
         }
     }
 
-    // ===============================
-    // PARSE THE CONFIGURATION OPTIONS
-    // ===============================
-
-    // Convert list to vector
-    std::vector<std::string> inputDataPortsNamesVector;
-    for (unsigned i = 0; i < inputDataPortsNamesList->size(); ++i) {
-        inputDataPortsNamesVector.emplace_back(inputDataPortsNamesList->get(i).asString());
-    }
-
-    yInfo() << logPrefix << "*** ========================";
-    for (unsigned i = 0; i < inputDataPortsNamesVector.size(); ++i) {
-        yInfo() << logPrefix << "*** Wearable Data Port" << i + 1 << "  :"
-                << inputDataPortsNamesVector[i];
-    }
-
-    yInfo() << logPrefix << "*** ========================";
-
-    // Carrier optional configuration
-    std::string carrier = "";
-    if (config.check("carrier")) {
-        carrier = config.find("carrier").asString();
-    }
 
     // Initialize the network
     pImpl->network = yarp::os::Network();
     if (!yarp::os::Network::initialized() || !yarp::os::Network::checkNetwork(5.0)) {
         yError() << logPrefix << "YARP server wasn't found active.";
         return false;
-    }
-
-    // ==========================
-    // CONFIGURE INPUT DATA PORTS
-    // ==========================
-    yDebug() << logPrefix << "Configuring input data ports";
-
-    for (unsigned i = 0; i < config.find("wearableDataPorts").asList()->size(); ++i) {
-        pImpl->inputPortsWearData.emplace_back(new yarp::os::BufferedPort<msg::WearableData>());
-        pImpl->inputPortsWearData.back()->useCallback(*this);
-
-        if (!pImpl->inputPortsWearData.back()->open("...")) {
-            yError() << logPrefix << "Failed to open local input port";
-            return false;
-        }
-    }
-
-    // ================
-    // OPEN INPUT PORTS
-    // ================
-    yDebug() << logPrefix << "Opening input ports";
-
-    for (unsigned i = 0; i < config.find("wearableDataPorts").asList()->size(); ++i) {
-        if (!yarp::os::Network::connect(inputDataPortsNamesVector[i],
-                                        pImpl->inputPortsWearData[i]->getName(),
-                                        carrier)) {
-            yError() << logPrefix << "Failed to connect " << inputDataPortsNamesVector[i]
-                     << " with " << pImpl->inputPortsWearData[i]->getName();
-            return false;
-        }
     }
 
     // We use callbacks on the input ports, the loop is a no-op
@@ -728,7 +752,6 @@ bool IWearRemapper::attachAll(const yarp::dev::PolyDriverList& driverList)
             auto* newSensor = const_cast<sensor::impl::ForceTorque6DSensor*>(constSensor);
             newSensor->setStatus(sensor->getSensorStatus());
             pImpl->forceTorque6DSensors.emplace(sensor->getSensorName(), newSensor);
-            std::cerr << "adding ft6d sensor: " << sensor->getSensorName() << std::endl;
         }
         for (const auto& sensor : iWear->getFreeBodyAccelerationSensors()) {
             const auto* constSensor = static_cast<const sensor::impl::FreeBodyAccelerationSensor*>(sensor.get());
@@ -805,7 +828,11 @@ bool IWearRemapper::attachAll(const yarp::dev::PolyDriverList& driverList)
 
     }
 
-    pImpl->firstRun = false;
+    // if there are not input ports there is no need to wait for the first data
+    if (!pImpl->inputDataPorts) {
+        pImpl->firstRun = false;
+    }
+
     return true;
 }
 

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -695,6 +695,125 @@ SensorPtr<const sensor::ISensor> IWearRemapper::getSensor(const sensor::SensorNa
     return nullptr;
 }
 
+bool IWearRemapper::attachAll(const yarp::dev::PolyDriverList& driverList)
+{
+    for(int p=0; p<driverList.size(); p++)
+    {
+        wearable::IWear* iWear = nullptr;
+        if (!driverList[p]->poly->view(iWear)) {
+            yError() << logPrefix << "Failed to view the IWear interface from the PolyDriver.";
+            return false;
+        }
+
+        for (const auto& sensor : iWear->getAccelerometers()) {
+            const auto* constSensor = static_cast<const sensor::impl::Accelerometer*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::Accelerometer*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->accelerometers.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getEmgSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::EmgSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::EmgSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->emgSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getForce3DSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::Force3DSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::Force3DSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->force3DSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getForceTorque6DSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::ForceTorque6DSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::ForceTorque6DSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->forceTorque6DSensors.emplace(sensor->getSensorName(), newSensor);
+            std::cerr << "adding ft6d sensor: " << sensor->getSensorName() << std::endl;
+        }
+        for (const auto& sensor : iWear->getFreeBodyAccelerationSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::FreeBodyAccelerationSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::FreeBodyAccelerationSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->freeBodyAccelerationSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getGyroscopes()) {
+            const auto* constSensor = static_cast<const sensor::impl::Gyroscope*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::Gyroscope*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->gyroscopes.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getMagnetometers()) {
+            const auto* constSensor = static_cast<const sensor::impl::Magnetometer*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::Magnetometer*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->magnetometers.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getOrientationSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::OrientationSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::OrientationSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->orientationSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getPoseSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::PoseSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::PoseSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->poseSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getPositionSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::PositionSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::PositionSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->positionSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getSkinSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::SkinSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::SkinSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->skinSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getTemperatureSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::TemperatureSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::TemperatureSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->temperatureSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getTorque3DSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::Torque3DSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::Torque3DSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->torque3DSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getVirtualLinkKinSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::VirtualLinkKinSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::VirtualLinkKinSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->virtualLinkKinSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getVirtualJointKinSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::VirtualJointKinSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::VirtualJointKinSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->virtualJointKinSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+        for (const auto& sensor : iWear->getVirtualSphericalJointKinSensors()) {
+            const auto* constSensor = static_cast<const sensor::impl::VirtualSphericalJointKinSensor*>(sensor.get());
+            auto* newSensor = const_cast<sensor::impl::VirtualSphericalJointKinSensor*>(constSensor);
+            newSensor->setStatus(sensor->getSensorStatus());
+            pImpl->virtualSphericalJointKinSensors.emplace(sensor->getSensorName(), newSensor);
+        }
+
+    }
+
+    pImpl->firstRun = false;
+    return true;
+}
+
+bool IWearRemapper::detachAll()
+{
+    return true;
+}
+
 VectorOfSensorPtr<const sensor::ISensor>
 IWearRemapper::getSensors(const sensor::SensorType type) const
 {

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -46,8 +46,6 @@ public:
     msg::WearableData wearableData;
     std::vector<std::unique_ptr<yarp::os::BufferedPort<msg::WearableData>>> inputPortsWearData;
 
-    std::map<wearable::sensor::SensorName, size_t> sensorNameToIndex;
-
     // Sensors stored for exposing wearable::IWear
     std::map<std::string, std::shared_ptr<sensor::impl::Accelerometer>> accelerometers;
     std::map<std::string, std::shared_ptr<sensor::impl::EmgSensor>> emgSensors;


### PR DESCRIPTION
Until now, the IWear remapper had the dual role of **network client** (converting yarp port to interface) and **remapper** (merging multiple signals). 

This PR extend the IWearRemapper capabilities concerning the second role (**remapping**) enabling it to merge multiple interfaces (until now it was only capable of merging signals from ports). In the future the other role (**network client**) might be delegated to a dedicated device.

As a consequence of this change:
- The `IWearRemapper` inherit from IMultipleWrapper (see [here](https://github.com/robotology/wearables/commit/2beda7472fc37660643b4090afafb70ac8def998#diff-128791d37501a3ed0419157fd075de56bbe657fec48eceee92686d964991d6f4R36) and can be attached to IWear interfaces (see [here](https://github.com/robotology/wearables/commit/2beda7472fc37660643b4090afafb70ac8def998#diff-60515704f6df80730c05b305ebbbd80fe339824111c8a824d7ac5ef4c31ff127R700-R707))
- The `WearableDataPorts` option becomes optional (see [here](https://github.com/robotology/wearables/commit/d6db509741d867b311eb44c24074c45c6ea99c24))