### PR TITLE
Remove unused actuators message definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Remove unused definition in actuators thrift messages(https://github.com/robotology/wearables/pull/171).
+
 ## [1.6.0] - 2022-09-21
 
 ### Changed

--- a/msgs/thrift/WearableActuators.thrift
+++ b/msgs/thrift/WearableActuators.thrift
@@ -4,12 +4,6 @@ namespace yarp wearable.msg
 // Actuators metadata
 // ==================
 
-enum ActuatorStatus {
-  ERROR,
-  OK
-  UNKNOWN,
-}
-
 enum ActuatorType {
   HAPTIC,
   MOTOR,
@@ -19,40 +13,6 @@ enum ActuatorType {
 struct ActuatorInfo {
   1: string name;
   2: ActuatorType type;
-  3: ActuatorStatus status;
-}
-
-// =====================
-// Actuators data struct
-// ======================
-
-//TODO: Update relevant data struct for each actuator,
-//that needs to be communication to a data port
-
-struct Haptic {
-  1: ActuatorInfo info;
-  2: double value;
-}
-
-struct Motor {
-  1: ActuatorInfo info;
-  2: double value;
-}
-
-struct Heater {
-  1: ActuatorInfo info;
-  2: double value;
-}
-
-// ============================
-// WearableActuatorsData struct
-// ============================
-
-struct WearableActuatorsData {
-1: required string producerName;
-2: optional map<string, Haptic> hapticActuators;
-3: optional map<string, Motor> motorActuators;
-4: optional map<string, Heater> heaterActuators;
 }
 
 // ==========================


### PR DESCRIPTION
This PR to remove unused definitions for actuators message.

### Reason

Currently, the following line will not compile:

```c++
#include <thrift/WearableData.h>
#include <thrift/WearableActuatorCommand.h>

int main()
{
    return 0;
}
```
With the following message:

```bash
In file included from <superbuild-dir>/build/install/include/thrift/ActuatorInfo.h:16,
                 from <superbuild-dir>/build/install/include/thrift/WearableActuatorCommand.h:16,
                 from myCode.cpp:13:
<superbuild-dir>/build/install/include/thrift/ActuatorStatus.h:21:13: error: ‘ERROR’ conflicts with a previous declaration
   21 |     ERROR = 0,
      |             ^
In file included from <superbuild-dir>/build/install/include/thrift/SensorInfo.h:16,
                 from <superbuild-dir>/build/install/include/thrift/Accelerometer.h:16,
                 from <superbuild-dir>/build/install/include/thrift/WearableData.h:16,
                 from myCode.cpp:12:
<superbuild-dir>/build/install/include/thrift/SensorStatus.h:21:5: note: previous declaration ‘wearable::msg::SensorStatus wearable::msg::ERROR’
```

Because of the following definitions in the thrift messages:

- https://github.com/robotology/wearables/blob/21fbd8a2b2bcb034423bb284a9199d4aa747c8b1/msgs/thrift/WearableActuators.thrift#L7-L11
- https://github.com/robotology/wearables/blob/21fbd8a2b2bcb034423bb284a9199d4aa747c8b1/msgs/thrift/WearableData.thrift#L7-L15
