### PR TITLE
Use std::mutex instead of std::recursive_mutex in IWearRemapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use `std::mutex` instead of `std::recursive_mutex` in IWearRemapper (https://github.com/robotology/wearables/pull/174).
+
 ### Fixed
 - Fixed management of the `period` parameter in `HapticGlove` device (https://github.com/robotology/wearables/pull/173). 
 

--- a/bindings/python/msgs/CMakeLists.txt
+++ b/bindings/python/msgs/CMakeLists.txt
@@ -9,4 +9,4 @@ add_wearables_python_module(
     NAME MsgsBindings
     SOURCES src/WearableData.cpp src/Module.cpp
     HEADERS ${H_PREFIX}/WearableData.h ${H_PREFIX}/BufferedPort.h ${H_PREFIX}/Module.h
-    LINK_LIBRARIES Wearable::WearableData YARP::YARP_OS)
+    LINK_LIBRARIES Wearable::WearableData YARP::YARP_os)

--- a/devices/IWearRemapper/CMakeLists.txt
+++ b/devices/IWearRemapper/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(IWearRemapper PUBLIC
     Wearable::WearableData
     Wearable::SensorsImpl
     YARP::YARP_dev
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_init)
 
 yarp_install(

--- a/devices/IWearRemapper/include/IWearRemapper.h
+++ b/devices/IWearRemapper/include/IWearRemapper.h
@@ -53,7 +53,7 @@ public:
     void threadRelease() override;
 
     // TypedReaderCallback
-    void onRead(msg::WearableData& wearData) override;
+    void onRead(msg::WearableData& wearData, const yarp::os::TypedReader<msg::WearableData>& typedReader) override;
 
     // PreciselyTimed interface
     yarp::os::Stamp getLastInputStamp() override;

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <mutex>
 #include <utility>
+#include <unordered_map>
 
 const std::string WrapperName = "IWearRemapper";
 const std::string logPrefix = WrapperName + " :";
@@ -52,25 +53,25 @@ public:
     std::vector<std::unique_ptr<yarp::os::BufferedPort<msg::WearableData>>> inputPortsWearData;
 
     // Sensors stored for exposing wearable::IWear
-    std::map<std::string, std::shared_ptr<sensor::impl::Accelerometer>> accelerometers;
-    std::map<std::string, std::shared_ptr<sensor::impl::EmgSensor>> emgSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::Force3DSensor>> force3DSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::ForceTorque6DSensor>> forceTorque6DSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::FreeBodyAccelerationSensor>>
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::Accelerometer>> accelerometers;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::EmgSensor>> emgSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::Force3DSensor>> force3DSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::ForceTorque6DSensor>> forceTorque6DSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::FreeBodyAccelerationSensor>>
         freeBodyAccelerationSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::Gyroscope>> gyroscopes;
-    std::map<std::string, std::shared_ptr<sensor::impl::Magnetometer>> magnetometers;
-    std::map<std::string, std::shared_ptr<sensor::impl::OrientationSensor>> orientationSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::PoseSensor>> poseSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::PositionSensor>> positionSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::SkinSensor>> skinSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::TemperatureSensor>> temperatureSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::Torque3DSensor>> torque3DSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::VirtualLinkKinSensor>>
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::Gyroscope>> gyroscopes;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::Magnetometer>> magnetometers;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::OrientationSensor>> orientationSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::PoseSensor>> poseSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::PositionSensor>> positionSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::SkinSensor>> skinSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::TemperatureSensor>> temperatureSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::Torque3DSensor>> torque3DSensors;
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::VirtualLinkKinSensor>>
         virtualLinkKinSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::VirtualJointKinSensor>>
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::VirtualJointKinSensor>>
         virtualJointKinSensors;
-    std::map<std::string, std::shared_ptr<sensor::impl::VirtualSphericalJointKinSensor>>
+    std::unordered_map<std::string, std::shared_ptr<sensor::impl::VirtualSphericalJointKinSensor>>
         virtualSphericalJointKinSensors;
 
     bool updateData(msg::WearableData& receivedWearData, bool create);
@@ -79,13 +80,13 @@ public:
     SensorPtr<const SensorInterface>
     getSensor(const sensor::SensorName name,
               const sensor::SensorType type,
-              const std::map<std::string, SensorPtr<SensorImpl>>& storage) const;
+              const std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage) const;
 
     template <typename SensorInterface, typename SensorImpl>
     SensorPtr<const SensorInterface>
     getOrCreateSensor(const sensor::SensorName name,
                     const sensor::SensorType type,
-                    std::map<std::string, SensorPtr<SensorImpl>>& storage,
+                    std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage,
                     bool create);
 
     SensorPtr<const sensor::IAccelerometer>
@@ -287,7 +288,7 @@ void IWearRemapper::run()
     return;
 }
 
-const std::map<msg::SensorStatus, sensor::SensorStatus> MapSensorStatus = {
+const std::unordered_map<msg::SensorStatus, sensor::SensorStatus> MapSensorStatus = {
     {msg::SensorStatus::OK, sensor::SensorStatus::Ok},
     {msg::SensorStatus::ERROR, sensor::SensorStatus::Error},
     {msg::SensorStatus::DATA_OVERFLOW, sensor::SensorStatus::Overflow},
@@ -1052,7 +1053,7 @@ template <typename SensorInterface, typename SensorImpl>
 SensorPtr<const SensorInterface>
 IWearRemapper::impl::getSensor(const sensor::SensorName name,
                                const sensor::SensorType type,
-                               const std::map<std::string, SensorPtr<SensorImpl>>& storage) const
+                               const std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage) const
 {
 
     if (storage.find(name) == storage.end()) {
@@ -1066,7 +1067,7 @@ template <typename SensorInterface, typename SensorImpl>
 SensorPtr<const SensorInterface>
 IWearRemapper::impl::getOrCreateSensor(const sensor::SensorName name,
                                const sensor::SensorType type,
-                               std::map<std::string, SensorPtr<SensorImpl>>& storage,
+                               std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage,
                                bool create)
 {
 

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -41,6 +41,8 @@ public:
     bool terminationCall = false;
     bool inputDataPorts = false;
     
+    bool allowDynamicData = true;
+
     // Flag to wait for first data received
     bool waitForAttachAll = false;
 
@@ -158,6 +160,11 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
         pImpl->waitForAttachAll = config.find("waitForAttachAll").asBool();
     }
 
+    if (!config.check("allowDynamicData") || !config.find("allowDynamicData").isBool() )
+    {
+        yInfo() << logPrefix << "Cannot find a suitable allowDynamicData parameter, using default value"<<pImpl->allowDynamicData;
+    }
+    pImpl->allowDynamicData = config.find("allowDynamicData").asBool();
 
     pImpl->inputDataPorts = config.check("wearableDataPorts");
 

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -1078,12 +1078,22 @@ IWearRemapper::impl::getSensor(const sensor::SensorName name,
                                const sensor::SensorType type,
                                const std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage) const
 {
-
-    if (storage.find(name) == storage.end()) {
-        return nullptr;
+    SensorPtr<const SensorInterface> ptr = nullptr;
+    if(allowDynamicData)
+    {
+        mutex.lock();
     }
 
-    return storage.at(name);
+    if (storage.find(name) != storage.end()) {
+        ptr = storage.at(name);
+    }
+
+    if(allowDynamicData)
+    {
+        mutex.unlock();
+    }
+
+    return ptr;
 }
 
 template <typename SensorInterface, typename SensorImpl>
@@ -1093,18 +1103,20 @@ IWearRemapper::impl::getOrCreateSensor(const sensor::SensorName name,
                                std::unordered_map<std::string, SensorPtr<SensorImpl>>& storage,
                                bool create)
 {
+    bool found = storage.find(name)!=storage.end();
 
-    auto sensor = getSensor<SensorInterface, SensorImpl>(
-        name, type, storage);
+    if(!found && !create)
+    {
+        return nullptr;
+    }
 
-    if (!sensor && create) {
+    if (!found && create) {
         const auto newSensor =
             std::make_shared<SensorImpl>(name, wearable::sensor::SensorStatus::Unknown);
         storage.emplace(name, newSensor);
-        sensor = storage[name];
     }
 
-    return sensor;
+    return storage[name];
 }
 
 wearable::SensorPtr<const sensor::IAccelerometer>
@@ -1224,116 +1236,100 @@ IWearRemapper::impl::getVirtualSphericalJointKinSensor(const sensor::SensorName 
 }
 
 
-//////////// Interface
+// IWear Interface
 
 wearable::SensorPtr<const sensor::IAccelerometer>
 IWearRemapper::getAccelerometer(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getAccelerometer(name);
 }
 
 wearable::SensorPtr<const sensor::IEmgSensor>
 IWearRemapper::getEmgSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getEmgSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IForce3DSensor>
 IWearRemapper::getForce3DSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getForce3DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IForceTorque6DSensor>
 IWearRemapper::getForceTorque6DSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getForceTorque6DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IFreeBodyAccelerationSensor>
 IWearRemapper::getFreeBodyAccelerationSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getFreeBodyAccelerationSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IGyroscope>
 IWearRemapper::getGyroscope(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getGyroscope(name);
 }
 
 wearable::SensorPtr<const sensor::IMagnetometer>
 IWearRemapper::getMagnetometer(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getMagnetometer(name);
 }
 
 wearable::SensorPtr<const sensor::IOrientationSensor>
 IWearRemapper::getOrientationSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getOrientationSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IPoseSensor>
 IWearRemapper::getPoseSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getPoseSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IPositionSensor>
 IWearRemapper::getPositionSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getPositionSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ISkinSensor>
 IWearRemapper::getSkinSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getSkinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ITemperatureSensor>
 IWearRemapper::getTemperatureSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getTemperatureSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ITorque3DSensor>
 IWearRemapper::getTorque3DSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getTorque3DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualLinkKinSensor>
 IWearRemapper::getVirtualLinkKinSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getVirtualLinkKinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualJointKinSensor>
 IWearRemapper::getVirtualJointKinSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getVirtualJointKinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualSphericalJointKinSensor>
 IWearRemapper::getVirtualSphericalJointKinSensor(const sensor::SensorName name) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     return pImpl->getVirtualSphericalJointKinSensor(name);
 }

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -166,10 +166,14 @@ bool IWearRemapper::open(yarp::os::Searchable& config)
 
     if (!config.check("allowDynamicData") || !config.find("allowDynamicData").isBool() )
     {
-        yInfo() << logPrefix << "Cannot find a suitable allowDynamicData parameter, using default value"<<pImpl->allowDynamicData;
+        yInfo() << logPrefix << "Cannot find a suitable allowDynamicData parameter, using default value.";
     }
-    pImpl->allowDynamicData = config.find("allowDynamicData").asBool();
-
+    else
+    {
+        pImpl->allowDynamicData = config.find("allowDynamicData").asBool();
+    }
+    yInfo() << logPrefix << "Using allowDynamicData parameter:"<<pImpl->allowDynamicData;
+    
     pImpl->inputDataPorts = config.check("wearableDataPorts");
 
     if (pImpl->inputDataPorts) {

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -235,6 +235,9 @@ const std::map<msg::SensorStatus, sensor::SensorStatus> MapSensorStatus = {
 
 void IWearRemapper::onRead(msg::WearableData& receivedWearData)
 {
+    std::lock_guard<std::recursive_mutex> lock(pImpl->mutex);
+
+
     if (pImpl->terminationCall) {
         return;
     }
@@ -635,17 +638,13 @@ void IWearRemapper::onRead(msg::WearableData& receivedWearData)
         sensor->setStatus(MapSensorStatus.at(wearDataInputSensor.info.status));
     }
 
-    {
-        std::lock_guard<std::recursive_mutex> lock(pImpl->mutex);
+    // Update the timestamp
+    pImpl->timestamp.sequenceNumber++;
+    pImpl->timestamp.time = yarp::os::Time::now();
 
-        // Update the timestamp
-        pImpl->timestamp.sequenceNumber++;
-        pImpl->timestamp.time = yarp::os::Time::now();
-
-        // This is used to handle the overall status of IWear
-        if (pImpl->firstRun) {
-            pImpl->firstRun = false;
-        }
+    // This is used to handle the overall status of IWear
+    if (pImpl->firstRun) {
+        pImpl->firstRun = false;
     }
 }
 

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -980,9 +980,17 @@ bool IWearRemapper::detachAll()
 VectorOfSensorPtr<const sensor::ISensor>
 IWearRemapper::getSensors(const sensor::SensorType type) const
 {
-    std::lock_guard<std::mutex> lock(pImpl->mutex);
     VectorOfSensorPtr<const sensor::ISensor> sensors;
 
+    if(pImpl->firstRun)
+    {
+        return sensors;
+    }
+    if(pImpl->allowDynamicData)
+    {
+        pImpl->mutex.lock();
+    }
+    
     switch (type) {
         case sensor::SensorType::Accelerometer:
             for (const auto& s : pImpl->accelerometers) {
@@ -1067,6 +1075,11 @@ IWearRemapper::getSensors(const sensor::SensorType type) const
         case sensor::SensorType::Invalid:
             yWarning() << logPrefix << "Requested Invalid sensor type";
             break;
+    }
+
+    if(pImpl->allowDynamicData)
+    {
+        pImpl->mutex.unlock();
     }
 
     return sensors;

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -75,7 +75,61 @@ public:
     SensorPtr<const SensorInterface>
     getSensor(const sensor::SensorName name,
               const sensor::SensorType type,
-              std::map<std::string, SensorPtr<SensorImpl>>& storage);
+              std::map<const std::string, SensorPtr<SensorImpl>>& storage) const;
+
+    template <typename SensorInterface, typename SensorImpl>
+    SensorPtr<const SensorInterface>
+    getOrMakeSensor(const sensor::SensorName name,
+              const sensor::SensorType type,
+              std::map<const std::string, SensorPtr<SensorImpl>>& storage);
+
+    SensorPtr<const sensor::IAccelerometer>
+    getAccelerometer(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IEmgSensor>
+    getEmgSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IForce3DSensor>
+    getForce3DSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IForceTorque6DSensor>
+    getForceTorque6DSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IFreeBodyAccelerationSensor>
+    getFreeBodyAccelerationSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IGyroscope>
+    getGyroscope(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IMagnetometer>
+    getMagnetometer(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IOrientationSensor>
+    getOrientationSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IPoseSensor>
+    getPoseSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IPositionSensor>
+    getPositionSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::ISkinSensor>
+    getSkinSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::ITemperatureSensor>
+    getTemperatureSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::ITorque3DSensor>
+    getTorque3DSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IVirtualLinkKinSensor>
+    getVirtualLinkKinSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IVirtualJointKinSensor>
+    getVirtualJointKinSensor(const sensor::SensorName /*name*/) const;
+
+    SensorPtr<const sensor::IVirtualSphericalJointKinSensor>
+    getVirtualSphericalJointKinSensor(const sensor::SensorName /*name*/) const;
 };
 
 // ==============
@@ -249,7 +303,8 @@ void IWearRemapper::onRead(msg::WearableData& receivedWearData)
         // ====================
         // EXPOSE THE INTERFACE
         // ====================
-        auto isensor = getAccelerometer(inputSensorName);
+        auto isensor = pImpl->getOrMakeSensor<const sensor::IAccelerometer, sensor::impl::Accelerometer>(
+                            inputSensorName, sensor::SensorType::Accelerometer, pImpl->accelerometers);
         if (!isensor) {
             yError() << logPrefix << "Failed to get Accelerometer" << inputSensorName;
             askToStop();
@@ -959,10 +1014,27 @@ template <typename SensorInterface, typename SensorImpl>
 SensorPtr<const SensorInterface>
 IWearRemapper::impl::getSensor(const sensor::SensorName name,
                                const sensor::SensorType type,
-                               std::map<std::string, SensorPtr<SensorImpl>>& storage)
+                               std::map<const std::string, SensorPtr<SensorImpl>>& storage) const
 {
 
     if (storage.find(name) == storage.end()) {
+        return nullptr;
+    }
+
+    return storage[name];
+}
+
+template <typename SensorInterface, typename SensorImpl>
+SensorPtr<const SensorInterface>
+IWearRemapper::impl::getOrMakeSensor(const sensor::SensorName name,
+                               const sensor::SensorType type,
+                               std::map<const std::string, SensorPtr<SensorImpl>>& storage)
+{
+
+    auto sensor = getSensor<SensorInterface, SensorImpl>(
+        name, type, storage);
+
+    if (!sensor) {
         const auto newSensor =
             std::make_shared<SensorImpl>(name, wearable::sensor::SensorStatus::Unknown);
         storage.emplace(name, newSensor);
@@ -972,135 +1044,232 @@ IWearRemapper::impl::getSensor(const sensor::SensorName name,
 }
 
 wearable::SensorPtr<const sensor::IAccelerometer>
+IWearRemapper::impl::getAccelerometer(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IAccelerometer, sensor::impl::Accelerometer>(
+        name, wearable::sensor::SensorType::Accelerometer, accelerometers);
+}
+
+wearable::SensorPtr<const sensor::IEmgSensor>
+IWearRemapper::impl::getEmgSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IEmgSensor, sensor::impl::EmgSensor>(
+        name, sensor::SensorType::EmgSensor, emgSensors);
+}
+
+wearable::SensorPtr<const sensor::IForce3DSensor>
+IWearRemapper::impl::getForce3DSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IForce3DSensor, sensor::impl::Force3DSensor>(
+        name, sensor::SensorType::Force3DSensor, force3DSensors);
+}
+
+wearable::SensorPtr<const sensor::IForceTorque6DSensor>
+IWearRemapper::impl::getForceTorque6DSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IForceTorque6DSensor, sensor::impl::ForceTorque6DSensor>(
+        name, sensor::SensorType::ForceTorque6DSensor, forceTorque6DSensors);
+}
+
+wearable::SensorPtr<const sensor::IFreeBodyAccelerationSensor>
+IWearRemapper::impl::getFreeBodyAccelerationSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IFreeBodyAccelerationSensor,
+                            sensor::impl::FreeBodyAccelerationSensor>(
+        name, sensor::SensorType::FreeBodyAccelerationSensor, freeBodyAccelerationSensors);
+}
+
+wearable::SensorPtr<const sensor::IGyroscope>
+IWearRemapper::impl::getGyroscope(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IGyroscope, sensor::impl::Gyroscope>(
+        name, sensor::SensorType::Gyroscope, gyroscopes);
+}
+
+wearable::SensorPtr<const sensor::IMagnetometer>
+IWearRemapper::impl::getMagnetometer(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IMagnetometer, sensor::impl::Magnetometer>(
+        name, sensor::SensorType::Magnetometer, magnetometers);
+}
+
+wearable::SensorPtr<const sensor::IOrientationSensor>
+IWearRemapper::impl::getOrientationSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IOrientationSensor, sensor::impl::OrientationSensor>(
+        name, sensor::SensorType::OrientationSensor, orientationSensors);
+}
+
+wearable::SensorPtr<const sensor::IPoseSensor>
+IWearRemapper::impl::getPoseSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IPoseSensor, sensor::impl::PoseSensor>(
+        name, sensor::SensorType::PoseSensor, poseSensors);
+}
+
+wearable::SensorPtr<const sensor::IPositionSensor>
+IWearRemapper::impl::getPositionSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IPositionSensor, sensor::impl::PositionSensor>(
+        name, sensor::SensorType::PositionSensor, positionSensors);
+}
+
+wearable::SensorPtr<const sensor::ISkinSensor>
+IWearRemapper::impl::getSkinSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::ISkinSensor, sensor::impl::SkinSensor>(
+        name, sensor::SensorType::SkinSensor, skinSensors);
+}
+
+wearable::SensorPtr<const sensor::ITemperatureSensor>
+IWearRemapper::impl::getTemperatureSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::ITemperatureSensor, sensor::impl::TemperatureSensor>(
+        name, sensor::SensorType::TemperatureSensor, temperatureSensors);
+}
+
+wearable::SensorPtr<const sensor::ITorque3DSensor>
+IWearRemapper::impl::getTorque3DSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::ITorque3DSensor, sensor::impl::Torque3DSensor>(
+        name, sensor::SensorType::Torque3DSensor, torque3DSensors);
+}
+
+wearable::SensorPtr<const sensor::IVirtualLinkKinSensor>
+IWearRemapper::impl::getVirtualLinkKinSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IVirtualLinkKinSensor, sensor::impl::VirtualLinkKinSensor>(
+            name, sensor::SensorType::VirtualLinkKinSensor, virtualLinkKinSensors);
+}
+
+wearable::SensorPtr<const sensor::IVirtualJointKinSensor>
+IWearRemapper::impl::getVirtualJointKinSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IVirtualJointKinSensor, sensor::impl::VirtualJointKinSensor>(
+            name, sensor::SensorType::VirtualJointKinSensor, virtualJointKinSensors);
+}
+
+wearable::SensorPtr<const sensor::IVirtualSphericalJointKinSensor>
+IWearRemapper::impl::getVirtualSphericalJointKinSensor(const sensor::SensorName name) const
+{
+    return getSensor<const sensor::IVirtualSphericalJointKinSensor,
+                            sensor::impl::VirtualSphericalJointKinSensor>(
+        name,
+        sensor::SensorType::VirtualSphericalJointKinSensor,
+        virtualSphericalJointKinSensors);
+}
+
+
+//////////// Interface
+
+wearable::SensorPtr<const sensor::IAccelerometer>
 IWearRemapper::getAccelerometer(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IAccelerometer, sensor::impl::Accelerometer>(
-        name, wearable::sensor::SensorType::Accelerometer, pImpl->accelerometers);
+    return pImpl->getAccelerometer(name);
 }
 
 wearable::SensorPtr<const sensor::IEmgSensor>
 IWearRemapper::getEmgSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IEmgSensor, sensor::impl::EmgSensor>(
-        name, sensor::SensorType::EmgSensor, pImpl->emgSensors);
+    return pImpl->getEmgSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IForce3DSensor>
 IWearRemapper::getForce3DSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IForce3DSensor, sensor::impl::Force3DSensor>(
-        name, sensor::SensorType::Force3DSensor, pImpl->force3DSensors);
+    return pImpl->getForce3DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IForceTorque6DSensor>
 IWearRemapper::getForceTorque6DSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IForceTorque6DSensor, sensor::impl::ForceTorque6DSensor>(
-        name, sensor::SensorType::ForceTorque6DSensor, pImpl->forceTorque6DSensors);
+    return pImpl->getForceTorque6DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IFreeBodyAccelerationSensor>
 IWearRemapper::getFreeBodyAccelerationSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IFreeBodyAccelerationSensor,
-                            sensor::impl::FreeBodyAccelerationSensor>(
-        name, sensor::SensorType::FreeBodyAccelerationSensor, pImpl->freeBodyAccelerationSensors);
+    return pImpl->getFreeBodyAccelerationSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IGyroscope>
 IWearRemapper::getGyroscope(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IGyroscope, sensor::impl::Gyroscope>(
-        name, sensor::SensorType::Gyroscope, pImpl->gyroscopes);
+    return pImpl->getGyroscope(name);
 }
 
 wearable::SensorPtr<const sensor::IMagnetometer>
 IWearRemapper::getMagnetometer(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IMagnetometer, sensor::impl::Magnetometer>(
-        name, sensor::SensorType::Magnetometer, pImpl->magnetometers);
+    return pImpl->getMagnetometer(name);
 }
 
 wearable::SensorPtr<const sensor::IOrientationSensor>
 IWearRemapper::getOrientationSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IOrientationSensor, sensor::impl::OrientationSensor>(
-        name, sensor::SensorType::OrientationSensor, pImpl->orientationSensors);
+    return pImpl->getOrientationSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IPoseSensor>
 IWearRemapper::getPoseSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IPoseSensor, sensor::impl::PoseSensor>(
-        name, sensor::SensorType::PoseSensor, pImpl->poseSensors);
+    return pImpl->getPoseSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IPositionSensor>
 IWearRemapper::getPositionSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IPositionSensor, sensor::impl::PositionSensor>(
-        name, sensor::SensorType::PositionSensor, pImpl->positionSensors);
+    return pImpl->getPositionSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ISkinSensor>
 IWearRemapper::getSkinSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::ISkinSensor, sensor::impl::SkinSensor>(
-        name, sensor::SensorType::SkinSensor, pImpl->skinSensors);
+    return pImpl->getSkinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ITemperatureSensor>
 IWearRemapper::getTemperatureSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::ITemperatureSensor, sensor::impl::TemperatureSensor>(
-        name, sensor::SensorType::TemperatureSensor, pImpl->temperatureSensors);
+    return pImpl->getTemperatureSensor(name);
 }
 
 wearable::SensorPtr<const sensor::ITorque3DSensor>
 IWearRemapper::getTorque3DSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::ITorque3DSensor, sensor::impl::Torque3DSensor>(
-        name, sensor::SensorType::Torque3DSensor, pImpl->torque3DSensors);
+    return pImpl->getTorque3DSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualLinkKinSensor>
 IWearRemapper::getVirtualLinkKinSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl
-        ->getSensor<const sensor::IVirtualLinkKinSensor, sensor::impl::VirtualLinkKinSensor>(
-            name, sensor::SensorType::VirtualLinkKinSensor, pImpl->virtualLinkKinSensors);
+    return pImpl->getVirtualLinkKinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualJointKinSensor>
 IWearRemapper::getVirtualJointKinSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl
-        ->getSensor<const sensor::IVirtualJointKinSensor, sensor::impl::VirtualJointKinSensor>(
-            name, sensor::SensorType::VirtualJointKinSensor, pImpl->virtualJointKinSensors);
+    return pImpl->getVirtualJointKinSensor(name);
 }
 
 wearable::SensorPtr<const sensor::IVirtualSphericalJointKinSensor>
 IWearRemapper::getVirtualSphericalJointKinSensor(const sensor::SensorName name) const
 {
     std::lock_guard<std::mutex> lock(pImpl->mutex);
-    return pImpl->getSensor<const sensor::IVirtualSphericalJointKinSensor,
-                            sensor::impl::VirtualSphericalJointKinSensor>(
-        name,
-        sensor::SensorType::VirtualSphericalJointKinSensor,
-        pImpl->virtualSphericalJointKinSensors);
+    return pImpl->getVirtualSphericalJointKinSensor(name);
 }

--- a/devices/Paexo/test-application/CMakeLists.txt
+++ b/devices/Paexo/test-application/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(${PROJECT_NAME} paexo-test-application.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC
     IWear::IWear
     WearableActuators::WearableActuators
-    YARP::YARP_OS
+    YARP::YARP_os
     YARP::YARP_init)
 
 

--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -14,7 +14,7 @@ yarp_add_idl(WEARABLEDATA_FILES thrift/WearableData.thrift)
 
 add_library(WearableData ${WEARABLEDATA_FILES} thrift/WearableData.thrift)
 add_library(Wearable::WearableData ALIAS WearableData)
-target_link_libraries(WearableData YARP::YARP_OS)
+target_link_libraries(WearableData YARP::YARP_os)
 
 # Extract the include directory from the files names
 foreach(file ${WEARABLEDATA_FILES})
@@ -62,7 +62,7 @@ yarp_add_idl(WEARABLEACTUATORS_FILES thrift/WearableActuators.thrift)
 
 add_library(WearableActuators ${WEARABLEACTUATORS_FILES} thrift/WearableActuators.thrift)
 add_library(Wearable::WearableActuators ALIAS WearableActuators)
-target_link_libraries(WearableActuators YARP::YARP_OS)
+target_link_libraries(WearableActuators YARP::YARP_os)
 
 # Extract the include directory from the files names
 foreach(file ${WEARABLEACTUATORS_FILES})
@@ -110,7 +110,7 @@ install(FILES ${WEARABLEACTUATORS_FILES}
 yarp_add_idl(XSENSSUITCONTROL thrift/XsensSuitControlService.thrift)
 
 add_library(XsensSuitControl ${XSENSSUITCONTROL} thrift/XsensSuitControlService.thrift)
-target_link_libraries(XsensSuitControl YARP::YARP_OS)
+target_link_libraries(XsensSuitControl YARP::YARP_os)
 
 # Extract the include directory from the files names
 foreach(file ${XSENSSUITCONTROL})

--- a/wrappers/IWearActuators/CMakeLists.txt
+++ b/wrappers/IWearActuators/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(IWearActuatorsWrapper PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 target_link_libraries(IWearActuatorsWrapper PUBLIC
-    IWear WearableActuators YARP::YARP_dev YARP::YARP_OS YARP::YARP_init)
+    IWear WearableActuators YARP::YARP_dev YARP::YARP_os YARP::YARP_init)
 
 yarp_install(
     TARGETS IWearActuatorsWrapper


### PR DESCRIPTION
This PR introduces the following 2 changes in `IWearRemapper`:
- Fixed use of mutex when reading the port in https://github.com/robotology/wearables/pull/174/commits/d90cc76692e545ba5e9a41a3227a5ee4a8ae01a1
- Switch to use  `std::mutex` instead of `std::recursive_mutex` in https://github.com/robotology/wearables/pull/174/commits/3c3a4d7902aba66e86e1384277ad294700fe1413
-  Fixed first read check from all ports in https://github.com/robotology/wearables/pull/174/commits/9661562c8695de64482e8fab88a1568424bd1902