### PR TITLE
Remove deprecated YARP headers

### DIFF
--- a/devices/HapticGlove/include/HapticGlove.h
+++ b/devices/HapticGlove/include/HapticGlove.h
@@ -13,8 +13,8 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
-#include <yarp/dev/SerialInterfaces.h>
+#include <yarp/dev/IPreciselyTimed.h>
+#include <yarp/dev/ISerialDevice.h>
 #include <yarp/os/PeriodicThread.h>
 
 namespace wearable {

--- a/devices/IAnalogSensorToIWear/include/IAnalogSensorToIWear.h
+++ b/devices/IAnalogSensorToIWear/include/IAnalogSensorToIWear.h
@@ -12,8 +12,9 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IPreciselyTimed.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <memory>
 

--- a/devices/ICub/include/ICub.h
+++ b/devices/ICub/include/ICub.h
@@ -12,7 +12,7 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <memory>
 

--- a/devices/IFrameTransformToIWear/include/IFrameTransformToIWear.h
+++ b/devices/IFrameTransformToIWear/include/IFrameTransformToIWear.h
@@ -12,8 +12,9 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IPreciselyTimed.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 
 #include <memory>
 

--- a/devices/IWearRemapper/include/IWearRemapper.h
+++ b/devices/IWearRemapper/include/IWearRemapper.h
@@ -12,9 +12,10 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/PeriodicThread.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/TypedReaderCallback.h>
 
 #include <memory>

--- a/devices/IWearRemapper/src/IWearRemapper.cpp
+++ b/devices/IWearRemapper/src/IWearRemapper.cpp
@@ -11,7 +11,7 @@
 #include "Wearable/IWear/Sensors/impl/SensorsImpl.h"
 #include "thrift/WearableData.h"
 
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>

--- a/devices/Paexo/include/Paexo.h
+++ b/devices/Paexo/include/Paexo.h
@@ -11,9 +11,10 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/Wrapper.h>
-#include <yarp/dev/SerialInterfaces.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
+#include <yarp/dev/ISerialDevice.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <yarp/os/PeriodicThread.h>
 

--- a/devices/XsensSuit/include/XsensSuit.h
+++ b/devices/XsensSuit/include/XsensSuit.h
@@ -13,7 +13,7 @@
 #include "Wearable/IWear/IWear.h"
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 
 #include <memory>
 

--- a/wrappers/IWear/include/IWearWrapper.h
+++ b/wrappers/IWear/include/IWearWrapper.h
@@ -11,7 +11,8 @@
 
 #include <memory>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 namespace wearable {

--- a/wrappers/IWear/src/IWearWrapper.cpp
+++ b/wrappers/IWear/src/IWearWrapper.cpp
@@ -10,7 +10,7 @@
 #include "Wearable/IWear/IWear.h"
 #include "thrift/WearableData.h"
 
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>
 

--- a/wrappers/IWearActuators/include/IWearActuatorsWrapper.h
+++ b/wrappers/IWearActuators/include/IWearActuatorsWrapper.h
@@ -11,7 +11,8 @@
 
 #include <memory>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 #include <yarp/os/TypedReaderCallback.h>
 

--- a/wrappers/IWearLogger/include/IWearLogger.h
+++ b/wrappers/IWearLogger/include/IWearLogger.h
@@ -11,7 +11,8 @@
 
 #include <memory>
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 namespace wearable

--- a/wrappers/IWearLogger/src/IWearLogger.cpp
+++ b/wrappers/IWearLogger/src/IWearLogger.cpp
@@ -13,7 +13,7 @@
 #include <functional>
 #include <mutex>
 #include <vector>
-#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/BufferedPort.h>
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>

--- a/wrappers/IXsensMVNControl/include/IXsensMVNControlWrapper.h
+++ b/wrappers/IXsensMVNControl/include/IXsensMVNControlWrapper.h
@@ -10,7 +10,8 @@
 #define IXSENS_MVN_CONTROL_WRAPPER_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/Wrapper.h>
+#include <yarp/dev/IWrapper.h>
+#include <yarp/dev/IMultipleWrapper.h>
 #include <yarp/os/PeriodicThread.h>
 
 #include <memory>


### PR DESCRIPTION
Removing deprecated YARP headers (see https://github.com/robotology/wearables/issues/177)