### PR TITLE
CMake: Fix compilation of optional devices by defining options to enable them before they are used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ option(ENABLE_HapticGlove "Flag that enables building Haptic Sense Glove wearabl
 
 # Flag to enable IWearFrameVisualizer module
 find_package(iDynTree QUIET)
-option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" OFF)
+option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" ${iDynTree_FOUND})
 
 # Flag to enable IWearLogger device
 find_package(robometry QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,23 +65,6 @@ if(WIN32)
   add_compile_definitions(_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING)
 endif()
 
-add_subdirectory(interfaces)
-add_subdirectory(impl)
-
-# Prepare YARP wrapper and devices
-find_package(YARP 3.2 REQUIRED)
-set(YARP_FORCE_DYNAMIC_PLUGINS ON)
-yarp_configure_plugins_installation(wearable)
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-add_subdirectory(msgs)
-add_subdirectory(devices)
-add_subdirectory(wrappers)
-add_subdirectory(app)
-add_subdirectory(modules)
-add_subdirectory(bindings)
-
 # Flag to enable Paexo wearable device
 option(WEARABLES_COMPILE_PYTHON_BINDINGS "Flag that enables building the bindings" OFF)
 
@@ -100,7 +83,7 @@ option(ENABLE_HapticGlove "Flag that enables building Haptic Sense Glove wearabl
 
 # Flag to enable IWearFrameVisualizer module
 find_package(iDynTree QUIET)
-option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" ${iDynTree_FOUND})
+option(ENABLE_FrameVisualizer "Flag that enables building IWearFrameVisualizer module" OFF)
 
 # Flag to enable IWearLogger device
 find_package(robometry QUIET)
@@ -108,3 +91,22 @@ option(ENABLE_Logger "Flag that enables building Wearable Logger device" ${robom
 
 # Flag to enable ICub wearable device
 option(ENABLE_ICub "Flag that enables building iCub wearable device" ${iDynTree_FOUND})
+
+add_subdirectory(interfaces)
+add_subdirectory(impl)
+
+# Prepare YARP wrapper and devices
+find_package(YARP 3.2 REQUIRED)
+set(YARP_FORCE_DYNAMIC_PLUGINS ON)
+yarp_configure_plugins_installation(wearable)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_subdirectory(msgs)
+add_subdirectory(devices)
+add_subdirectory(wrappers)
+add_subdirectory(app)
+add_subdirectory(modules)
+add_subdirectory(bindings)
+
+

--- a/modules/IWearFrameVisualizer/CMakeLists.txt
+++ b/modules/IWearFrameVisualizer/CMakeLists.txt
@@ -18,15 +18,13 @@ endmacro()
 
 set(EXE_TARGET_NAME IWearFrameVisualizerModule)
 
-
-find_package(IWear REQUIRED)
 find_package(YARP REQUIRED)
 find_package(iDynTree REQUIRED)
 
 add_executable(${EXE_TARGET_NAME} src/main.cpp)
 
 target_link_libraries(${EXE_TARGET_NAME} PUBLIC
-    IWear::IWear
+    Wearables::IWear
     YARP::YARP_os
     YARP::YARP_sig
     YARP::YARP_dev

--- a/modules/IWearFrameVisualizer/CMakeLists.txt
+++ b/modules/IWearFrameVisualizer/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(iDynTree REQUIRED)
 add_executable(${EXE_TARGET_NAME} src/main.cpp)
 
 target_link_libraries(${EXE_TARGET_NAME} PUBLIC
-    Wearables::IWear
+    IWear
     YARP::YARP_os
     YARP::YARP_sig
     YARP::YARP_dev


### PR DESCRIPTION
Fix https://github.com/robotology/wearables/issues/164 .
Fix https://github.com/robotology/wearables/issues/181 .

