### PR TITLE
Fix typo in IWearWrapper and IWearLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fixed EMG normalization value in IWearWrapper (https://github.com/robotology/wearables/pull/186)
+- Fixed EMG normalization value in IWearWrapper and IWearLogger (https://github.com/robotology/wearables/pull/186)
 
 ## [1.7.1] - 2023-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed EMG normalization value in IWearWrapper (https://github.com/robotology/wearables/pull/186)
+
 ## [1.7.1] - 2023-02-07
 
 ### Changed

--- a/wrappers/IWear/src/IWearWrapper.cpp
+++ b/wrappers/IWear/src/IWearWrapper.cpp
@@ -190,7 +190,7 @@ void IWearWrapper::run()
         for (const auto& sensor : pImpl->emgSensors) {
             double value, normalization;
             // double normalizationValue;
-            if (!sensor->getEmgSignal(value) || !sensor->getEmgSignal(normalization)) {
+            if (!sensor->getEmgSignal(value) || !sensor->getNormalizationValue(normalization)) {
                 yWarning() << logPrefix << "[EmgSensors] "
                          << "Failed to read data, "
                          << "sensor status is "

--- a/wrappers/IWearLogger/src/IWearLogger.cpp
+++ b/wrappers/IWearLogger/src/IWearLogger.cpp
@@ -300,7 +300,7 @@ void IWearLogger::run()
         for (const auto& sensor : pImpl->emgSensors) {
             double value, normalization;
             // double normalizationValue;
-            if (!sensor->getEmgSignal(value) || !sensor->getEmgSignal(normalization)) {
+            if (!sensor->getEmgSignal(value) || !sensor->getNormalizationValue(normalization)) {
                 yWarning() << logPrefix << "[EmgSensors] "
                            << "Failed to read data, "
                            << "sensor status is " << static_cast<int>(sensor->getSensorStatus());


### PR DESCRIPTION
As per title, this PR to fix a typo in `IWearWrapper` and `IWearLogger` that were using the same `get` call for the emg signal its normalization value.