### PR TITLE
Bump wearables version to 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2023-09-06
+
 ### Fixed
 - Fixed EMG normalization value in IWearWrapper and IWearLogger (https://github.com/robotology/wearables/pull/186).
 - Fixed IWearLogger termination when `BufferManager` configuration fails (https://github.com/robotology/wearables/pull/195).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-set(PROJECT_VERSION "1.7.1")
+set(PROJECT_VERSION "1.7.2")
 
 set (WEARABLES_PROJECT_NAME Wearables)
 


### PR DESCRIPTION
### Fixed
- Fixed EMG normalization value in IWearWrapper and IWearLogger (https://github.com/robotology/wearables/pull/186).
- Fixed IWearLogger termination when `BufferManager` configuration fails (https://github.com/robotology/wearables/pull/195).

### Changed
- The license of the repo changed to [`BSD-3-Clause`](https://spdx.org/licenses/BSD-3-Clause.html) (https://github.com/robotology/wearables/pull/192).