### PR TITLE
Bump wearables version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2023-11-17
+
 ### Changed
 - Update iframetransform_to_iwear.xml to use new TF device (https://github.com/robotology/wearables/pull/202)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-set(PROJECT_VERSION "1.7.2")
+set(PROJECT_VERSION "1.8.0")
 
 set (WEARABLES_PROJECT_NAME Wearables)
 


### PR DESCRIPTION
### Changed
- Update iframetransform_to_iwear.xml to use new TF device (https://github.com/robotology/wearables/pull/202)

### Added
- CMake: Permit to explictly specify Python installation directory by setting the `WEARABLES_PYTHON_INSTALL_DIR` CMake variable (https://github.com/robotology/wearables/pull/197).
