### PR TITLE
Fix compatibility with YARP 3.10

### DIFF
--- a/devices/Paexo/src/Paexo.cpp
+++ b/devices/Paexo/src/Paexo.cpp
@@ -60,8 +60,6 @@ public:
     std::unique_ptr<CmdParser> cmdPro;
     yarp::os::RpcServer rpcPort;
 
-    std::string serialComPortName;
-
     // Paexo data buffer
     PaexoData paexoData;
 
@@ -805,9 +803,6 @@ bool Paexo::attach(yarp::dev::PolyDriver* poly)
     else {
         yInfo() << LogPrefix << "ISerialDevice interface viewed correctly";
     }
-
-    // Get the comport name of the serial device
-    pImpl->serialComPortName = poly->getValue("comport").asString();
 
     // TODO: Check if the ISerialDevice interface is configured correctly
     // I do not see any method to check this

--- a/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
+++ b/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
@@ -20,7 +20,7 @@ constexpr double DefaultPeriod = 0.01;
 class IWearActuatorsWrapper::impl : public wearable::msg::WearableActuatorCommand
 {
 public:
-    std::string attachedWearableDeviceName;
+    std::string attachedWearableDeviceKey;
 
     std::string actuatorCommandInputPortName;
     yarp::os::BufferedPort<wearable::msg::WearableActuatorCommand> actuatorCommandInputPort;
@@ -94,7 +94,7 @@ void IWearActuatorsWrapper::onRead(msg::WearableActuatorCommand& wearableActuato
    // Check if the commanded actuator name is available
    if (pImpl->actuatorsMap.find(info.name) == pImpl->actuatorsMap.end())
    {
-       yWarning() << "Requested actuator with name " << info.name << " is not available in " << pImpl->attachedWearableDeviceName << " wearable device \n \t Ignoring wearable actuation command.";
+       yWarning() << "Requested actuator with name " << info.name << " is not available in " << pImpl->attachedWearableDeviceKey << " wearable device \n \t Ignoring wearable actuation command.";
    }
    else // process the wearable actuator command
    {
@@ -153,8 +153,6 @@ bool IWearActuatorsWrapper::attach(yarp::dev::PolyDriver* poly)
         return false;
     }
 
-    pImpl->attachedWearableDeviceName = poly->getValue("device").asString();
-
     if (pImpl->iWear || !poly->view(pImpl->iWear) || !pImpl->iWear) {
         yError() << LogPrefix << "Failed to view the IWear interface from the PolyDriver.";
         return false;
@@ -162,7 +160,7 @@ bool IWearActuatorsWrapper::attach(yarp::dev::PolyDriver* poly)
 
     // Check and add all the available actuators
 
-    yInfo() << LogPrefix << "Finding available actuators from " << pImpl->attachedWearableDeviceName << " wearable deive ...";
+    yInfo() << LogPrefix << "Finding available actuators from " << pImpl->attachedWearableDeviceKey << " wearable deive ...";
 
     for (const auto& a : pImpl->iWear->getHapticActuators())
     {
@@ -226,6 +224,9 @@ bool IWearActuatorsWrapper::attachAll(const yarp::dev::PolyDriverList& driverLis
         yError() << LogPrefix << "Passed PolyDriverDescriptor is nullptr.";
         return false;
     }
+    
+    // Save key that identifies the driver
+    driver->key;
 
     return attach(driver->poly);
 }

--- a/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
+++ b/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
@@ -20,7 +20,7 @@ constexpr double DefaultPeriod = 0.01;
 class IWearActuatorsWrapper::impl : public wearable::msg::WearableActuatorCommand
 {
 public:
-    std::string attachedWearableDeviceKey = "defaultIWearActuatorsWrapperDevice"
+    std::string attachedWearableDeviceKey = "defaultIWearActuatorsWrapperDevice";
 
     std::string actuatorCommandInputPortName;
     yarp::os::BufferedPort<wearable::msg::WearableActuatorCommand> actuatorCommandInputPort;

--- a/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
+++ b/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
@@ -20,7 +20,7 @@ constexpr double DefaultPeriod = 0.01;
 class IWearActuatorsWrapper::impl : public wearable::msg::WearableActuatorCommand
 {
 public:
-    std::string attachedWearableDeviceKey;
+    std::string attachedWearableDeviceKey = "defaultIWearActuatorsWrapperDevice"
 
     std::string actuatorCommandInputPortName;
     yarp::os::BufferedPort<wearable::msg::WearableActuatorCommand> actuatorCommandInputPort;

--- a/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
+++ b/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
@@ -226,7 +226,7 @@ bool IWearActuatorsWrapper::attachAll(const yarp::dev::PolyDriverList& driverLis
     }
     
     // Save key that identifies the driver
-    driver->key;
+    pImpl->attachedWearableDeviceKey = driver->key;
 
     return attach(driver->poly);
 }


### PR DESCRIPTION
* `serialComPortName` is unused, so we remove it
* `attachedWearableDeviceName` is actually used for some print information, but it is not particular useful to print the `device`, as if you have multiple devices (for example, a left and right couple of device) both they will have the same `device` value. Instead, it is more useful to print the key that have been passed to the `attachAll` method, that is the name attribute of the `elem` tag child of the in the attach-related element of the yarprobotinterface xml, see for example https://github.com/robotology/wearables/blob/3d57b0b3dd9dae5293cbd5690f91dec4c473dd43/devices/HapticGlove/conf/HapticGlove.xml#L72 .

Fix https://github.com/robotology/wearables/issues/205 .