### PR TITLE
Fixed port name check if-statement logic

### DIFF
--- a/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
+++ b/wrappers/IWearActuators/src/IWearActuatorsWrapper.cpp
@@ -57,7 +57,7 @@ void IWearActuatorsWrapper::run()
 
 bool IWearActuatorsWrapper::open(yarp::os::Searchable& config)
 {
-    if (!config.check("actuatorCommandInputPortName") || !config.check("gloveActuatorCommandInputPortName"))
+    if (!config.check("actuatorCommandInputPortName") && !config.check("gloveActuatorCommandInputPortName"))
     {
         yError() << LogPrefix << "No actuator command input ports found.";
         return false;


### PR DESCRIPTION
This PR fixed the IF statement where it checks the actuator port names. 

cc @S-Dafarra 